### PR TITLE
Fix go module declared path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/adrianosela/border0-go
+module github.com/borderzero/border0-go
 
 go 1.20
 


### PR DESCRIPTION
## Fix go module declared path

Go module was initialized in a fork -- and so the path got borked. This sets things right.