### PR TITLE
Add Map function to slice package, fix goreportcard

### DIFF
--- a/lib/types/pointer/README.md
+++ b/lib/types/pointer/README.md
@@ -1,6 +1,6 @@
 # pointer
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/borderzero/border0-go/lib/types/pointer)](https://goreportcard.com/report/github.com/borderzero/border0-go/lib/types/pointer)
+[![Go Report Card](https://goreportcard.com/badge/github.com/borderzero/border0-go)](https://goreportcard.com/report/github.com/borderzero/border0-go)
 [![Documentation](https://godoc.org/github.com/borderzero/border0-go/lib/types/pointer?status.svg)](https://godoc.org/github.com/borderzero/border0-go/lib/types/pointer)
 [![license](https://img.shields.io/github/license/borderzero/border0-go.svg)](https://github.com/borderzero/border0-go/blob/master/LICENSE)
 

--- a/lib/types/set/README.md
+++ b/lib/types/set/README.md
@@ -1,6 +1,6 @@
 # set
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/borderzero/border0-go/lib/types/set)](https://goreportcard.com/report/github.com/borderzero/border0-go/lib/types/set)
+[![Go Report Card](https://goreportcard.com/badge/github.com/borderzero/border0-go)](https://goreportcard.com/report/github.com/borderzero/border0-go)
 [![Documentation](https://godoc.org/github.com/borderzero/border0-go/lib/types/set?status.svg)](https://godoc.org/github.com/borderzero/border0-go/lib/types/set)
 [![license](https://img.shields.io/github/license/borderzero/border0-go.svg)](https://github.com/borderzero/border0-go/blob/master/LICENSE)
 

--- a/lib/types/slice/README.md
+++ b/lib/types/slice/README.md
@@ -1,6 +1,6 @@
 # slice 
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/borderzero/border0-go/lib/types/slice)](https://goreportcard.com/report/github.com/borderzero/border0-go/lib/types/slice)
+[![Go Report Card](https://goreportcard.com/badge/github.com/borderzero/border0-go)](https://goreportcard.com/report/github.com/borderzero/border0-go)
 [![Documentation](https://godoc.org/github.com/borderzero/border0-go/lib/types/slice?status.svg)](https://godoc.org/github.com/borderzero/border0-go/lib/types/slice)
 [![license](https://img.shields.io/github/license/borderzero/border0-go.svg)](https://github.com/borderzero/border0-go/blob/master/LICENSE)
 

--- a/lib/types/slice/slice.go
+++ b/lib/types/slice/slice.go
@@ -19,3 +19,16 @@ func Transform[T any, V any](slice []T, fn func(T) V) []V {
 	}
 	return vs
 }
+
+// Map takes a slice of a given type and a function to extract
+// a map key from slice elements; it returns a map of these keys
+// to the original element. Note that if multiple elements in
+// the slice return the same key, the element that appears last
+// in the slice will be the (only) element that maps to the key.
+func Map[K comparable, V any](slice []V, fn func(V) K) map[K]V {
+	m := map[K]V{}
+	for _, v := range slice {
+		m[fn(v)] = v
+	}
+	return m
+}

--- a/service/connector/types/README.md
+++ b/service/connector/types/README.md
@@ -1,6 +1,6 @@
 # (connector) types
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/borderzero/border0-go/service/connector/types)](https://goreportcard.com/report/github.com/borderzero/border0-go/service/connector/types)
+[![Go Report Card](https://goreportcard.com/badge/github.com/borderzero/border0-go)](https://goreportcard.com/report/github.com/borderzero/border0-go)
 [![Documentation](https://godoc.org/github.com/borderzero/border0-go/service/connector/types?status.svg)](https://godoc.org/github.com/borderzero/border0-go/service/connector/types)
 [![license](https://img.shields.io/github/license/borderzero/border0-go.svg)](https://github.com/borderzero/border0-go/blob/master/LICENSE)
 


### PR DESCRIPTION
## Add Map function to slice package + fix goreportcard

- Go reportcard links now point to the top level module URL
- Adds the Map function to the slice package