### PR TITLE
Make AWS Regions Optional in Plugin Config

### DIFF
--- a/service/connector/types/plugin.go
+++ b/service/connector/types/plugin.go
@@ -48,7 +48,7 @@ type AwsCredentials struct {
 // BaseAwsPluginConfiguration represents configuration fields shared across all AWS related plugins.
 type BaseAwsPluginConfiguration struct {
 	AwsCredentials *AwsCredentials `json:"aws_credentials,omitempty"`
-	AwsRegions     []string        `json:"aws_regions"`
+	AwsRegions     []string        `json:"aws_regions,omitempty"`
 }
 
 // BaseDiscoveryPluginConfiguration represents configuration fields shared across all discovery related plugins.


### PR DESCRIPTION
## Make AWS Regions Optional in Plugin Config

Add the `"omitempty"` directive to the json tag of regions in aws related connector plugin configuration.