### PR TITLE
[ME-1617] Remove PluginType and Enabled from Plugin Configuration

### DIFF
--- a/service/connector/types/plugin.go
+++ b/service/connector/types/plugin.go
@@ -25,9 +25,6 @@ const (
 
 // PluginConfiguration represents configuration for a Border0 connector plugin.
 type PluginConfiguration struct {
-	PluginType string `json:"plugin_type"`
-	Enabled    bool   `json:"enabled"`
-
 	AwsEc2DiscoveryPluginConfiguration     *AwsEc2DiscoveryPluginConfiguration     `json:"aws_ec2_discovery_plugin_configuration,omitempty"`
 	AwsEcsDiscoveryPluginConfiguration     *AwsEcsDiscoveryPluginConfiguration     `json:"aws_ecs_discovery_plugin_configuration,omitempty"`
 	AwsRdsDiscoveryPluginConfiguration     *AwsRdsDiscoveryPluginConfiguration     `json:"aws_rds_discovery_plugin_configuration,omitempty"`


### PR DESCRIPTION
### [ME-1617] Remove PluginType and Enabled from Plugin Configuration

We've decided we don't want these as part of the configuration object. Perhaps a higher level object -- does not need to be defined now.

[ME-1617]: https://mysocket.atlassian.net/browse/ME-1617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ