### PR TITLE
[ME-1667] Remove Statuses Config Opt from K8s Plugin

### DIFF
--- a/service/connector/types/plugin.go
+++ b/service/connector/types/plugin.go
@@ -112,9 +112,8 @@ type KubernetesDiscoveryPluginConfiguration struct {
 
 	Namespaces []string `json:"namespaces,omitempty"`
 
-	IncludeWithStatuses []string            `json:"include_with_statuses,omitempty"`
-	IncludeWithLabels   map[string][]string `json:"include_with_labels,omitempty"`
-	ExcludeWithLabels   map[string][]string `json:"exclude_with_labels,omitempty"`
+	IncludeWithLabels map[string][]string `json:"include_with_labels,omitempty"`
+	ExcludeWithLabels map[string][]string `json:"exclude_with_labels,omitempty"`
 }
 
 // NetworkDiscoveryPluginConfiguration represents configuration for the network_discovery plugin.


### PR DESCRIPTION
[[ME-1667](https://mysocket.atlassian.net/browse/ME-1667)] Remove Statuses Config Opt from K8s Plugin

We decided we will do k8s discovery at the service level -- k8s services don't have a status.

[ME-1667]: https://mysocket.atlassian.net/browse/ME-1667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ