### PR TITLE
[ME-1673] Add MatchesFilters to maps library

### DIFF
--- a/lib/types/maps/maps.go
+++ b/lib/types/maps/maps.go
@@ -8,3 +8,59 @@ func EnsureNotNil[K comparable, V any](m map[K]V) map[K]V {
 	}
 	return make(map[K]V)
 }
+
+// MatchesFilters returns true if the given map
+// matches the given inclusion and exclusion filters.
+// This requires that the map's values are comparable.
+func MatchesFilters[K comparable, V comparable](
+	kv map[K]V,
+	inclusion map[K][]V,
+	exclusion map[K][]V,
+) bool {
+	included := (inclusion == nil)
+	excluded := false
+
+	if inclusion != nil {
+		for key, value := range kv {
+			if matchesFilter(key, value, inclusion) {
+				included = true
+				break
+			}
+		}
+	}
+
+	if exclusion != nil {
+		for key, value := range kv {
+			if matchesFilter(key, value, exclusion) {
+				excluded = true
+				break
+			}
+		}
+	}
+
+	return included && !excluded
+}
+
+// matchesFilter returns true if a given key-value
+// pair matches a given filter of key-value options.
+func matchesFilter[K comparable, V comparable](
+	key K,
+	value V,
+	filter map[K][]V,
+) bool {
+	for filterKey, filterValues := range filter {
+		if key == filterKey {
+			// we interpret empty filter values
+			// as "match any value of the key"
+			if len(filterValues) == 0 {
+				return true
+			}
+			for _, filterValue := range filterValues {
+				if value == filterValue {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## [ME-1673] Add MatchesFilters to maps library

This is currently implemented as part of border0's discovery library. We are just moving it here so it can be reused more widely.



[ME-1673]: https://mysocket.atlassian.net/browse/ME-1673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ