### PR TITLE
[ME-1672] Add SSM Status Checks to EC2 Discovery

### DIFF
--- a/service/connector/types/plugin.go
+++ b/service/connector/types/plugin.go
@@ -67,6 +67,7 @@ type AwsEc2DiscoveryPluginConfiguration struct {
 	IncludeWithStates []string            `json:"include_with_states,omitempty"`
 	IncludeWithTags   map[string][]string `json:"include_with_tags,omitempty"`
 	ExcludeWithTags   map[string][]string `json:"exclude_with_tags,omitempty"`
+	CheckSsmStatus    bool                `json:"check_ssm_status"`
 }
 
 // AwsEcsDiscoveryPluginConfiguration represents configuration for the aws_ecs_discovery plugin.


### PR DESCRIPTION
## [[ME-1672](https://mysocket.atlassian.net/browse/ME-1672)] Add SSM Status Checks to EC2 Discovery

We discussed we would not have a standalone SSM discovery plugin; we would have it be an option of the EC2 discovery plugin.

### Fixes:
- Part of https://mysocket.atlassian.net/browse/ME-1672

[ME-1672]: https://mysocket.atlassian.net/browse/ME-1672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ