### PR TITLE
[ME-1679] Remove cluster status opt from ecs plugin config

### DIFF
--- a/service/connector/types/plugin.go
+++ b/service/connector/types/plugin.go
@@ -75,9 +75,8 @@ type AwsEcsDiscoveryPluginConfiguration struct {
 	BaseAwsPluginConfiguration       // extends
 	BaseDiscoveryPluginConfiguration // extends
 
-	IncludeWithStatuses []string            `json:"include_with_statuses,omitempty"`
-	IncludeWithTags     map[string][]string `json:"include_with_tags,omitempty"`
-	ExcludeWithTags     map[string][]string `json:"exclude_with_tags,omitempty"`
+	IncludeWithTags map[string][]string `json:"include_with_tags,omitempty"`
+	ExcludeWithTags map[string][]string `json:"exclude_with_tags,omitempty"`
 }
 
 // AwsRdsDiscoveryPluginConfiguration represents configuration for the aws_rds_discovery plugin.


### PR DESCRIPTION
## [[ME-1679](https://mysocket.atlassian.net/browse/ME-1679)] Changes to ECS Discovery

Accounts for changes to ecs discovery (no longer scanning clusters, scanning services)

### Fixes:
- part of https://mysocket.atlassian.net/browse/ME-1679

[ME-1679]: https://mysocket.atlassian.net/browse/ME-1679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ