### PR TITLE
[ME-1739] Add connector metadata types

### DIFF
--- a/service/connector/types/metadata.go
+++ b/service/connector/types/metadata.go
@@ -1,0 +1,20 @@
+package types
+
+// ConnectorMetadata represents informational data about a connector.
+type ConnectorMetadata struct {
+	AwsEc2IdentityMetadata *AwsEc2IdentityMetadata `json:"aws_ec2_identity_metadata,omitempty"`
+}
+
+// AwsEc2IdentityMetadata represents metadata for connectors running on AWS EC2 instances.
+type AwsEc2IdentityMetadata struct {
+	AwsAccountId        string `json:"aws_account_id"`
+	AwsRegion           string `json:"aws_region"`
+	AwsAvailabilityZone string `json:"aws_availability_zone"`
+	Ec2InstanceId       string `json:"ec2_instance_id"`
+	Ec2InstanceType     string `json:"ec2_instance_type"`
+	Ec2ImageId          string `json:"ec2_image_id"`
+	KernelId            string `json:"kernel_id"`
+	RamdiskId           string `json:"radisk_id"`
+	Architecture        string `json:"architecture"`
+	PrivateIpAddress    string `json:"private_ip_address"`
+}

--- a/service/connector/types/upstream_config.go
+++ b/service/connector/types/upstream_config.go
@@ -55,10 +55,6 @@ type AWSConfiguration struct {
 	Region string `json:"region"`
 	// InstanceID of the AWS configuration.
 	InstanceID string `json:"instance_id"`
-	// AvailabilityZone of the AWS configuration.
-	AvailabilityZone string `json:"availability_zone"`
-	// AwsProfile of the AWS configuration.
-	AwsProfile string `json:"aws_profile"`
 	// AwsCredentials are optional and represent AWS credentials for the configuration.
 	AwsCredentials *AwsCredentials `json:"aws_credentials,omitempty"`
 }


### PR DESCRIPTION
## [ME-1739](https://mysocket.atlassian.net/browse/ME-1739) Add connector metadata types

- Adds `ConnectorMetadata` with an inner object for ec2 config.

The idea is that this object will be stored in its entirety as JSON. Note that there is no `connector metadata type` field. This is because a connector can have multiple types of metadata.

- Removes unused aws availability zone and duplicate AWS profile object in AWSConfiguration (used aws profile is inside aws credentials object).

[ME-1739]: https://mysocket.atlassian.net/browse/ME-1739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ