### PR TITLE
/lib: Add CountWhere slice fn

### DIFF
--- a/lib/types/slice/slice.go
+++ b/lib/types/slice/slice.go
@@ -34,3 +34,14 @@ func Map[T any, K comparable, V any](slice []T, fn func(T) (K, V)) map[K]V {
 	}
 	return m
 }
+
+// CountWhere returns the number of elements in a slice that satisfy a given condition.
+func CountWhere[T any](slice []T, condition func(T) bool) int {
+	count := 0
+	for _, e := range slice {
+		if condition(e) {
+			count++
+		}
+	}
+	return count
+}


### PR DESCRIPTION
## `/lib`: Add `CountWhere` to `slice` package

A small function to count the elements in a slice that satisfy a condition.

---

Usage in the API's connector serializer:

```
// SerializeConnector returns a connector in its serialized form
func SerializeConnector(c models.Connector) Connector {
	connector := Connector{
		// ...
		ActivePlugins: CountWhere(c.ConnectorPlugins, pluginEnabled),
		// ...
	}
	return connector
}

func pluginEnabled(plugin models.ConnectorPlugin) bool {
	return pointer.ValueOrZero(plugin.Enabled)
}
```