### PR TITLE
[ME-1801] Add upstream connection type for built in ssh

### DIFF
--- a/service/connector/types/upstream_config.go
+++ b/service/connector/types/upstream_config.go
@@ -7,6 +7,8 @@ const (
 	UpstreamConnectionTypeAwsEC2Connection = "aws_ec2_connect"
 	// UpstreamConnectionTypeAwsSSM represents a AWS SSM type of upstream connection.
 	UpstreamConnectionTypeAwsSSM = "aws_ssm"
+	// UpstreamConnectionTypeBuiltInSshServer represents the Border0 built-in SSH server.
+	UpstreamConnectionTypeBuiltInSshServer = "built_in_ssh_server"
 	// UpstreamConnectionTypeDatabase represents a database type of upstream connection.
 	UpstreamConnectionTypeDatabase = "database"
 )


### PR DESCRIPTION
## [[ME-1801](https://mysocket.atlassian.net/browse/ME-1801)] Add upstream connection type for built in ssh

What's on the tin^

[ME-1801]: https://mysocket.atlassian.net/browse/ME-1801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ