### PR TITLE
ME-1847: make listener's `policyNames` fields optional

### DIFF
--- a/listen/option.go
+++ b/listen/option.go
@@ -2,6 +2,7 @@ package listen
 
 import (
 	"github.com/borderzero/border0-go/client"
+	"github.com/borderzero/border0-go/lib/types/pointer"
 )
 
 // Option is a function that configures a Listener.
@@ -36,7 +37,7 @@ func WithSocketName(name string) Option {
 // and made sure they exist, and then they will be attached to the listener's socket.
 func WithPolicies(names []string) Option {
 	return func(l *Listener) {
-		l.policyNames = names
+		l.policyNames = pointer.To(names)
 	}
 }
 


### PR DESCRIPTION
This is a patch to no-op behaviour from `ensurePoliciesAttached` method.

If `WithPolicies` option is NOT used and `policyNames` remains nil, no-op from listener's `ensurePoliciesAttached` method. If `WithPolicies` option is configured with an empty slice, all policies will be detached from listener's socket.