### PR TITLE
[ME-1822,ME-1823,ME-1824] Service Config for Connector Managed Sockets

### DIFF
--- a/types/service/http_service_configuration.go
+++ b/types/service/http_service_configuration.go
@@ -1,7 +1,33 @@
 package service
 
+const (
+	// HttpServiceTypeStandard is the http
+	// service type for standard http services.
+	HttpServiceTypeStandard = "standard"
+
+	// HttpServiceTypeConnectorFileServer is the http service
+	// type for the connector's built-in file webserver.
+	HttpServiceTypeConnectorFileServer = "connector_file_server"
+)
+
 // HttpServiceConfiguration represents service
 // configuration for http services (fka sockets).
 type HttpServiceConfiguration struct {
+	HttpServiceType string `json:"http_service_type"`
+
+	// mutually exclusive fields below
+	StandardHttpServiceConfiguration   *StandardHttpServiceConfiguration   `json:"standard_http_service_configuration,omitempty"`
+	FileServerHttpServiceConfiguration *FileServerHttpServiceConfiguration `json:"fileserver_http_service_configuration,omitempty"`
+}
+
+// StandardHttpServiceConfiguration represents service
+// configuration for standard http services (fka sockets).
+type StandardHttpServiceConfiguration struct {
 	HostnameAndPort // inherited
+}
+
+// FileServerHttpServiceConfiguration represents service
+// configuration for the connector built-in file webserver.
+type FileServerHttpServiceConfiguration struct {
+	TopLevelDirectory string `json:"top_level_directory,omitempty"`
 }

--- a/types/service/tls_service_configuration.go
+++ b/types/service/tls_service_configuration.go
@@ -1,7 +1,45 @@
 package service
 
+const (
+	// TlsServiceTypeStandard is the tls
+	// service type for standard tls services.
+	TlsServiceTypeStandard = "standard"
+
+	// TlsServiceTypeVpn is the tls service
+	// type for the connector's built-in vpn.
+	TlsServiceTypeVpn = "vpn"
+
+	// TlsServiceTypeHttpProxy is the tls service type
+	// for the connector's built-in http (forward) proxy.
+	TlsServiceTypeHttpProxy = "http_proxy"
+)
+
 // TlsServiceConfiguration represents service
 // configuration for tls services (fka sockets).
 type TlsServiceConfiguration struct {
+	TlsServiceType string `json:"tls_service_type,omitempty"`
+
+	// mutually exclusive fields below
+	StandardTlsServiceConfiguration  *StandardTlsServiceConfiguration  `json:"standard_tls_service_configuration,omitempty"`
+	VpnTlsServiceConfiguration       *VpnTlsServiceConfiguration       `json:"vpn_tls_service_configuration,omitempty"`
+	HttpProxyTlsServiceConfiguration *HttpProxyTlsServiceConfiguration `json:"http_proxy_tls_service_configuration,omitempty"`
+}
+
+// StandardTlsServiceConfiguration represents service
+// configuration for standard tls services (fka sockets).
+type StandardTlsServiceConfiguration struct {
 	HostnameAndPort // inherited
+}
+
+// VpnTlsServiceConfiguration represents service
+// configuration for vpn services services over the tls socket.
+type VpnTlsServiceConfiguration struct {
+	VpnSubnet string   `json:"vpn_subnet"`
+	Routes    []string `json:"routes,omitempty"`
+}
+
+// HttpProxyTlsServiceConfiguration represents service
+// configuration for http proxy services over the tls socket.
+type HttpProxyTlsServiceConfiguration struct {
+	HostAllowlist []string `json:"host_allowlist,omitempty"`
 }


### PR DESCRIPTION
## [[ME-1822](https://mysocket.atlassian.net/browse/ME-1822),[ME-1823](https://mysocket.atlassian.net/browse/ME-1823),[ME-1824](https://mysocket.atlassian.net/browse/ME-1824)] Service Config for Connector Managed Sockets

Adds service configuration for the remaining 3 connector-managed socket types e.g.
- The built-in http file server (http socket)
- The vpn (tls socket)
- The http proxy (tls socket)

Fixes:
- part of https://mysocket.atlassian.net/browse/ME-1822
- part of https://mysocket.atlassian.net/browse/ME-1823
- part of https://mysocket.atlassian.net/browse/ME-1824

[ME-1822]: https://mysocket.atlassian.net/browse/ME-1822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ME-1823]: https://mysocket.atlassian.net/browse/ME-1823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ME-1824]: https://mysocket.atlassian.net/browse/ME-1824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ