### PR TITLE
adding host sni header to standard http sockets

### DIFF
--- a/types/service/http_service_configuration.go
+++ b/types/service/http_service_configuration.go
@@ -23,8 +23,8 @@ type HttpServiceConfiguration struct {
 // StandardHttpServiceConfiguration represents service
 // configuration for standard http services (fka sockets).
 type StandardHttpServiceConfiguration struct {
-	HostnameAndPort // inherited
-	HostSniHeader   string
+	HostnameAndPort        // inherited
+	HostSniHeader   string `json:"host_sni_header,omitempty"`
 }
 
 // FileServerHttpServiceConfiguration represents service

--- a/types/service/http_service_configuration.go
+++ b/types/service/http_service_configuration.go
@@ -24,6 +24,7 @@ type HttpServiceConfiguration struct {
 // configuration for standard http services (fka sockets).
 type StandardHttpServiceConfiguration struct {
 	HostnameAndPort // inherited
+	HostSniHeader   string
 }
 
 // FileServerHttpServiceConfiguration represents service


### PR DESCRIPTION
# Summary
- adding host /sni header to the http standard services