### PR TITLE
ME-1893: new service config for connector socket

### DIFF
--- a/client/socket_test.go
+++ b/client/socket_test.go
@@ -376,27 +376,29 @@ func Test_APIClient_DeleteSocket(t *testing.T) {
 func Test_APIClient_SocketUpstreamConfigs(t *testing.T) {
 	t.Parallel()
 
+	// SSH upstream config with username and password
+	testConfig := service.Configuration{
+		ServiceType: service.ServiceTypeSsh,
+		SshServiceConfiguration: &service.SshServiceConfiguration{
+			SshServiceType: service.SshServiceTypeStandard,
+			StandardSshServiceConfiguration: &service.StandardSshServiceConfiguration{
+				SshAuthenticationType: service.StandardSshServiceAuthenticationTypeUsernameAndPassword,
+				UsernameAndPasswordAuthConfiguration: &service.UsernameAndPasswordAuthConfiguration{
+					Username: "test-username",
+					Password: "test-password",
+				},
+				HostnameAndPort: service.HostnameAndPort{
+					Hostname: "test-hostname",
+					Port:     22,
+				},
+			},
+		},
+	}
+
 	testConfigs := &SocketUpstreamConfigs{
 		List: []SocketUpstreamConfig{
-			// SSH upstream config with username and password
 			{
-				Config: service.Configuration{
-					ServiceType: service.ServiceTypeSsh,
-					SshServiceConfiguration: &service.SshServiceConfiguration{
-						SshServiceType: service.SshServiceTypeStandard,
-						StandardSshServiceConfiguration: &service.StandardSshServiceConfiguration{
-							SshAuthenticationType: service.StandardSshServiceAuthenticationTypeUsernameAndPassword,
-							UsernameAndPasswordAuthConfiguration: &service.UsernameAndPasswordAuthConfiguration{
-								Username: "test-username",
-								Password: "test-password",
-							},
-							HostnameAndPort: service.HostnameAndPort{
-								Hostname: "test-hostname",
-								Port:     22,
-							},
-						},
-					},
-				},
+				Config: testConfig,
 			},
 		},
 	}

--- a/types/service/configuration.go
+++ b/types/service/configuration.go
@@ -20,7 +20,7 @@ const (
 	ServiceTypeTls = "tls"
 )
 
-// Configuration represents service configuration.
+// Configuration represents upstream service configuration.
 type Configuration struct {
 	ServiceType string `json:"service_type"`
 
@@ -85,4 +85,18 @@ func (c *Configuration) Validate() error {
 	default:
 		return fmt.Errorf("service configuration has invalid service type \"%s\"", c.ServiceType)
 	}
+}
+
+// ConnectorServiceConfiguration includes both the connector socket and upstream service configuration
+type ConnectorServiceConfiguration struct {
+	ConnectorAuthenticationEnabled bool          `json:"connector_authentication_enabled"`
+	Upstream                       Configuration `json:"upstream_configuration"`
+}
+
+// Validate validates the ConnectorServiceConfiguration.
+func (c *ConnectorServiceConfiguration) Validate() error {
+	if err := c.Upstream.Validate(); err != nil {
+		return fmt.Errorf("invalid upstream configuration: %w", err)
+	}
+	return nil
 }


### PR DESCRIPTION
add a new config for connector socket that includes socket config like connector auth flag, and upstream configs for ssh, database, http and tls. this new top level connector socket config will be sent between api and connectors through grpc, it will replace the existing upstream config.