### PR TITLE
[ME-2244] Remove Username Provider Opts from Standard SSH Methods

### DIFF
--- a/types/service/ssh_service_configuration.go
+++ b/types/service/ssh_service_configuration.go
@@ -431,7 +431,7 @@ func (c *PrivateKeyAuthConfiguration) Validate() error {
 	if err := validateUsernameWithProvider(
 		c.UsernameProvider,
 		c.Username,
-		set.New(UsernameProviderPromptClient),
+		set.New[string](),
 	); err != nil {
 		return err
 	}
@@ -452,7 +452,7 @@ func (c *UsernameAndPasswordAuthConfiguration) Validate() error {
 	if err := validateUsernameWithProvider(
 		c.UsernameProvider,
 		c.Username,
-		set.New(UsernameProviderPromptClient),
+		set.New[string](),
 	); err != nil {
 		return err
 	}

--- a/types/service/ssh_service_configuration_test.go
+++ b/types/service/ssh_service_configuration_test.go
@@ -934,15 +934,6 @@ func Test_ValidateUsernameAndPasswordAuthConfiguration(t *testing.T) {
 			expectedError: fmt.Errorf("username must be provided when username_provider is \"%s\"", UsernameProviderDefined),
 		},
 		{
-			name: "Should fail when username type is 'prompt_client' and username is present",
-			configuration: &UsernameAndPasswordAuthConfiguration{
-				UsernameProvider: UsernameProviderPromptClient,
-				Username:         "username",
-				Password:         "password",
-			},
-			expectedError: fmt.Errorf("username must be empty when username_provider is %s", UsernameProviderPromptClient),
-		},
-		{
 			name: "Should fail when username provider is invalid",
 			configuration: &UsernameAndPasswordAuthConfiguration{
 				UsernameProvider: "not valid",
@@ -993,15 +984,6 @@ func Test_ValidatePrivateKeyAuthConfiguration(t *testing.T) {
 				PrivateKey:       mockPrivateKey,
 			},
 			expectedError: fmt.Errorf("username must be provided when username_provider is \"%s\"", UsernameProviderDefined),
-		},
-		{
-			name: "Should fail when username type is 'prompt_client' and username is present",
-			configuration: &PrivateKeyAuthConfiguration{
-				UsernameProvider: UsernameProviderPromptClient,
-				Username:         "username",
-				PrivateKey:       mockPrivateKey,
-			},
-			expectedError: fmt.Errorf("username must be empty when username_provider is %s", UsernameProviderPromptClient),
 		},
 		{
 			name: "Should fail when username provider is invalid",


### PR DESCRIPTION
## [ME-2244] Remove Username Provider Opts from Standard SSH Methods

We've decided that allowing prompting of username when the ssh mechanism is username + password OR username + private key is not desirable and only adds confusion to the product.