### PR TITLE
[ME-2352] Kubectl Exec Sockets Upstream Service Configuration

### DIFF
--- a/types/service/configuration.go
+++ b/types/service/configuration.go
@@ -31,7 +31,7 @@ type Configuration struct {
 }
 
 // Validate validates the Configuration.
-func (c *Configuration) Validate() error {
+func (c *Configuration) Validate(allowExperimentalFeatures bool) error {
 	switch c.ServiceType {
 
 	case ServiceTypeDatabase:
@@ -65,7 +65,7 @@ func (c *Configuration) Validate() error {
 		if c.SshServiceConfiguration == nil {
 			return fmt.Errorf("service configuration for service type \"ssh\" must have ssh service configuration defined")
 		}
-		if err := c.SshServiceConfiguration.Validate(); err != nil {
+		if err := c.SshServiceConfiguration.Validate(allowExperimentalFeatures); err != nil {
 			return fmt.Errorf("invalid ssh service configuration: %v", err)
 		}
 		return nil
@@ -96,8 +96,8 @@ type ConnectorServiceConfiguration struct {
 }
 
 // Validate validates the ConnectorServiceConfiguration.
-func (c *ConnectorServiceConfiguration) Validate() error {
-	if err := c.Upstream.Validate(); err != nil {
+func (c *ConnectorServiceConfiguration) Validate(allowExperimentalFeatures bool) error {
+	if err := c.Upstream.Validate(allowExperimentalFeatures); err != nil {
 		return fmt.Errorf("invalid upstream configuration: %w", err)
 	}
 	return nil

--- a/types/service/configuration_test.go
+++ b/types/service/configuration_test.go
@@ -78,7 +78,7 @@ func Test_Configuration_Validate(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, test.expectedError, test.configuration.Validate())
+			assert.Equal(t, test.expectedError, test.configuration.Validate(false))
 		})
 	}
 }
@@ -127,7 +127,7 @@ func Test_ConnectorSocketConfiguration_Validate(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			err := test.configuration.Validate()
+			err := test.configuration.Validate(false)
 			if test.expectedError == nil {
 				assert.Nil(t, err)
 			} else {

--- a/types/service/ssh_service_configuration_test.go
+++ b/types/service/ssh_service_configuration_test.go
@@ -268,7 +268,7 @@ func Test_ValidateSshServiceConfiguration(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, test.expectedError, test.configuration.Validate())
+			assert.Equal(t, test.expectedError, test.configuration.Validate(false))
 		})
 	}
 }


### PR DESCRIPTION
## [[ME-2352](https://mysocket.atlassian.net/browse/ME-2352)] Kubectl Exec Sockets Upstream Service Configuration

Upstream service configuration for kubectl exec sockets (behind a flag for validation).

### Testing

This means the change did not break any existing functionality.

```
✔ ~/go/src/github.com/borderzero/border0-go/types/service [ME_2352_k8s|✔]
09:40 $ go test .
ok  	github.com/borderzero/border0-go/types/service	0.168s
```