### PR TITLE
[ME-2373] Release Kubectl Exec Sockets

### DIFF
--- a/client/socket.go
+++ b/client/socket.go
@@ -113,15 +113,14 @@ func (api *APIClient) SignSocketKey(ctx context.Context, idOrName string, in *So
 // Socket represents a socket in Border0 API. A socket can be linked to a connector with upstream configuration.
 // Use `ConnectorID` to link a socket to a connector, and use `UpstreamConfig` to configure upstream for a socket.
 type Socket struct {
-	Name                           string            `json:"name"`
-	SocketID                       string            `json:"socket_id"`
-	SocketType                     string            `json:"socket_type"`
-	Description                    string            `json:"description,omitempty"`
-	UpstreamType                   string            `json:"upstream_type,omitempty"`
-	UpstreamHTTPHostname           string            `json:"upstream_http_hostname,omitempty"`
-	RecordingEnabled               bool              `json:"recording_enabled"`
-	ConnectorAuthenticationEnabled bool              `json:"connector_authentication_enabled"`
-	Tags                           map[string]string `json:"tags,omitempty"`
+	Name                 string            `json:"name"`
+	SocketID             string            `json:"socket_id"`
+	SocketType           string            `json:"socket_type"`
+	Description          string            `json:"description,omitempty"`
+	UpstreamType         string            `json:"upstream_type,omitempty"`
+	UpstreamHTTPHostname string            `json:"upstream_http_hostname,omitempty"`
+	RecordingEnabled     bool              `json:"recording_enabled"`
+	Tags                 map[string]string `json:"tags,omitempty"`
 
 	// link to a connector with upstream config
 	ConnectorID    string                 `json:"connector_id,omitempty"`

--- a/types/service/ssh_service_configuration.go
+++ b/types/service/ssh_service_configuration.go
@@ -286,11 +286,6 @@ func (c *SshServiceConfiguration) Validate(allowExperimentalFeatures bool) error
 		}
 		return nil
 	case SshServiceTypeKubectlExec:
-		if !allowExperimentalFeatures {
-			return fmt.Errorf(
-				"ssh service type \"%s\" is currently an experimental feature you are not allowed to use",
-				SshServiceTypeKubectlExec)
-		}
 		if nilcheck.AnyNotNil(c.AwsEc2ICSshServiceConfiguration, c.AwsSsmSshServiceConfiguration, c.BuiltInSshServiceConfiguration, c.StandardSshServiceConfiguration) {
 			return fmt.Errorf(
 				"ssh service type \"%s\" can only have kubectl exec ssh service configuration defined",


### PR DESCRIPTION
## [[ME-2373](https://mysocket.atlassian.net/browse/ME-2373)] Release Kubectl Exec Sockets

Also deprecated a NO-OP field in the socket config.

[ME-2373]: https://mysocket.atlassian.net/browse/ME-2373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ