### PR TITLE
[ME-2633] Add Special Handling of Retries for 404 Responses

### DIFF
--- a/.mockery.yaml
+++ b/.mockery.yaml
@@ -8,10 +8,10 @@ packages:
       HTTPRequester:
         config:
           dir: client/mocks
-          structname: ClientHTTPRequester
+          mockname: ClientHTTPRequester
           filename: client_http_requester.go
       Requester:
         config:
           dir: listen/mocks
-          structname: APIClientRequester
+          mockname: APIClientRequester
           filename: api_client_requester.go

--- a/client/connector.go
+++ b/client/connector.go
@@ -14,6 +14,7 @@ type ConnectorService interface {
 	UpdateConnector(ctx context.Context, in *Connector) (out *Connector, err error)
 	DeleteConnector(ctx context.Context, id string) (err error)
 	ConnectorTokens(ctx context.Context, connectorID string) (out *ConnectorTokens, err error)
+	ConnectorToken(ctx context.Context, connectorID string, tokenID string) (out *ConnectorToken, err error)
 	CreateConnectorToken(ctx context.Context, in *ConnectorToken) (out *ConnectorToken, err error)
 	DeleteConnectorToken(ctx context.Context, connectorID, tokenID string) (err error)
 }
@@ -77,6 +78,16 @@ func (api *APIClient) DeleteConnector(ctx context.Context, id string) (err error
 func (api *APIClient) ConnectorTokens(ctx context.Context, connectorID string) (out *ConnectorTokens, err error) {
 	out = new(ConnectorTokens)
 	_, err = api.request(ctx, http.MethodGet, fmt.Sprintf("/connector/%s/tokens", connectorID), nil, out)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// ConnectorToken fetches a connector's token by connector UUID and token UUID.
+func (api *APIClient) ConnectorToken(ctx context.Context, connectorID string, tokenID string) (out *ConnectorToken, err error) {
+	out = new(ConnectorToken)
+	_, err = api.request(ctx, http.MethodGet, fmt.Sprintf("/connector/%s/token/%s", connectorID, tokenID), nil, out)
 	if err != nil {
 		return nil, err
 	}

--- a/client/mocks/client_http_requester.go
+++ b/client/mocks/client_http_requester.go
@@ -57,6 +57,10 @@ func (_c *ClientHTTPRequester_Close_Call) RunAndReturn(run func()) *ClientHTTPRe
 func (_m *ClientHTTPRequester) Request(ctx context.Context, method string, path string, input interface{}, output interface{}) (int, error) {
 	ret := _m.Called(ctx, method, path, input, output)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Request")
+	}
+
 	var r0 int
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, string, string, interface{}, interface{}) (int, error)); ok {
@@ -109,13 +113,12 @@ func (_c *ClientHTTPRequester_Request_Call) RunAndReturn(run func(context.Contex
 	return _c
 }
 
-type mockConstructorTestingTNewClientHTTPRequester interface {
+// NewClientHTTPRequester creates a new instance of ClientHTTPRequester. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewClientHTTPRequester(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewClientHTTPRequester creates a new instance of ClientHTTPRequester. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewClientHTTPRequester(t mockConstructorTestingTNewClientHTTPRequester) *ClientHTTPRequester {
+}) *ClientHTTPRequester {
 	mock := &ClientHTTPRequester{}
 	mock.Mock.Test(t)
 

--- a/client/policy_test.go
+++ b/client/policy_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -70,7 +71,7 @@ func Test_APIClient_Policy(t *testing.T) {
 					Return(http.StatusNotFound, Error{Code: http.StatusNotFound, Message: "policy not found"})
 			},
 			givenID: "test-id",
-			wantErr: errors.New("policy [test-id] not found: failed after 1 attempt: 404: policy not found"),
+			wantErr: fmt.Errorf("policy [test-id] not found: failed after %d %s: 404: policy not found", notFoundRetryMax+1, attemptOrAttempts(notFoundRetryMax+1)),
 		},
 		{
 			name: "happy path",

--- a/client/socket_test.go
+++ b/client/socket_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -47,7 +48,7 @@ func Test_APIClient_Socket(t *testing.T) {
 					Return(http.StatusNotFound, Error{Code: http.StatusNotFound, Message: "socket not found"})
 			},
 			givenIDOrName: "test-name",
-			wantErr:       errors.New("socket [test-name] not found: failed after 1 attempt: 404: socket not found"),
+			wantErr:       fmt.Errorf("socket [test-name] not found: failed after %d %s: 404: socket not found", notFoundRetryMax+1, attemptOrAttempts(notFoundRetryMax+1)),
 		},
 		{
 			name: "happy path",

--- a/listen/mocks/api_client_requester.go
+++ b/listen/mocks/api_client_requester.go
@@ -29,6 +29,10 @@ func (_m *APIClientRequester) EXPECT() *APIClientRequester_Expecter {
 func (_m *APIClientRequester) AttachPoliciesToSocket(ctx context.Context, policyIDs []string, socketID string) error {
 	ret := _m.Called(ctx, policyIDs, socketID)
 
+	if len(ret) == 0 {
+		panic("no return value specified for AttachPoliciesToSocket")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, []string, string) error); ok {
 		r0 = rf(ctx, policyIDs, socketID)
@@ -73,6 +77,10 @@ func (_c *APIClientRequester_AttachPoliciesToSocket_Call) RunAndReturn(run func(
 func (_m *APIClientRequester) AttachPolicyToSocket(ctx context.Context, policyID string, socketID string) error {
 	ret := _m.Called(ctx, policyID, socketID)
 
+	if len(ret) == 0 {
+		panic("no return value specified for AttachPolicyToSocket")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
 		r0 = rf(ctx, policyID, socketID)
@@ -116,6 +124,10 @@ func (_c *APIClientRequester_AttachPolicyToSocket_Call) RunAndReturn(run func(co
 // Connector provides a mock function with given fields: ctx, id
 func (_m *APIClientRequester) Connector(ctx context.Context, id string) (*client.Connector, error) {
 	ret := _m.Called(ctx, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Connector")
+	}
 
 	var r0 *client.Connector
 	var r1 error
@@ -168,9 +180,73 @@ func (_c *APIClientRequester_Connector_Call) RunAndReturn(run func(context.Conte
 	return _c
 }
 
+// ConnectorToken provides a mock function with given fields: ctx, connectorID, tokenID
+func (_m *APIClientRequester) ConnectorToken(ctx context.Context, connectorID string, tokenID string) (*client.ConnectorToken, error) {
+	ret := _m.Called(ctx, connectorID, tokenID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ConnectorToken")
+	}
+
+	var r0 *client.ConnectorToken
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) (*client.ConnectorToken, error)); ok {
+		return rf(ctx, connectorID, tokenID)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) *client.ConnectorToken); ok {
+		r0 = rf(ctx, connectorID, tokenID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*client.ConnectorToken)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = rf(ctx, connectorID, tokenID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// APIClientRequester_ConnectorToken_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ConnectorToken'
+type APIClientRequester_ConnectorToken_Call struct {
+	*mock.Call
+}
+
+// ConnectorToken is a helper method to define mock.On call
+//   - ctx context.Context
+//   - connectorID string
+//   - tokenID string
+func (_e *APIClientRequester_Expecter) ConnectorToken(ctx interface{}, connectorID interface{}, tokenID interface{}) *APIClientRequester_ConnectorToken_Call {
+	return &APIClientRequester_ConnectorToken_Call{Call: _e.mock.On("ConnectorToken", ctx, connectorID, tokenID)}
+}
+
+func (_c *APIClientRequester_ConnectorToken_Call) Run(run func(ctx context.Context, connectorID string, tokenID string)) *APIClientRequester_ConnectorToken_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string))
+	})
+	return _c
+}
+
+func (_c *APIClientRequester_ConnectorToken_Call) Return(out *client.ConnectorToken, err error) *APIClientRequester_ConnectorToken_Call {
+	_c.Call.Return(out, err)
+	return _c
+}
+
+func (_c *APIClientRequester_ConnectorToken_Call) RunAndReturn(run func(context.Context, string, string) (*client.ConnectorToken, error)) *APIClientRequester_ConnectorToken_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ConnectorTokens provides a mock function with given fields: ctx, connectorID
 func (_m *APIClientRequester) ConnectorTokens(ctx context.Context, connectorID string) (*client.ConnectorTokens, error) {
 	ret := _m.Called(ctx, connectorID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ConnectorTokens")
+	}
 
 	var r0 *client.ConnectorTokens
 	var r1 error
@@ -227,6 +303,10 @@ func (_c *APIClientRequester_ConnectorTokens_Call) RunAndReturn(run func(context
 func (_m *APIClientRequester) Connectors(ctx context.Context) ([]client.Connector, error) {
 	ret := _m.Called(ctx)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Connectors")
+	}
+
 	var r0 []client.Connector
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context) ([]client.Connector, error)); ok {
@@ -280,6 +360,10 @@ func (_c *APIClientRequester_Connectors_Call) RunAndReturn(run func(context.Cont
 // CreateConnector provides a mock function with given fields: ctx, in
 func (_m *APIClientRequester) CreateConnector(ctx context.Context, in *client.Connector) (*client.Connector, error) {
 	ret := _m.Called(ctx, in)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateConnector")
+	}
 
 	var r0 *client.Connector
 	var r1 error
@@ -336,6 +420,10 @@ func (_c *APIClientRequester_CreateConnector_Call) RunAndReturn(run func(context
 func (_m *APIClientRequester) CreateConnectorToken(ctx context.Context, in *client.ConnectorToken) (*client.ConnectorToken, error) {
 	ret := _m.Called(ctx, in)
 
+	if len(ret) == 0 {
+		panic("no return value specified for CreateConnectorToken")
+	}
+
 	var r0 *client.ConnectorToken
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *client.ConnectorToken) (*client.ConnectorToken, error)); ok {
@@ -390,6 +478,10 @@ func (_c *APIClientRequester_CreateConnectorToken_Call) RunAndReturn(run func(co
 // CreatePolicy provides a mock function with given fields: ctx, in
 func (_m *APIClientRequester) CreatePolicy(ctx context.Context, in *client.Policy) (*client.Policy, error) {
 	ret := _m.Called(ctx, in)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreatePolicy")
+	}
 
 	var r0 *client.Policy
 	var r1 error
@@ -446,6 +538,10 @@ func (_c *APIClientRequester_CreatePolicy_Call) RunAndReturn(run func(context.Co
 func (_m *APIClientRequester) CreateSocket(ctx context.Context, in *client.Socket) (*client.Socket, error) {
 	ret := _m.Called(ctx, in)
 
+	if len(ret) == 0 {
+		panic("no return value specified for CreateSocket")
+	}
+
 	var r0 *client.Socket
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *client.Socket) (*client.Socket, error)); ok {
@@ -501,6 +597,10 @@ func (_c *APIClientRequester_CreateSocket_Call) RunAndReturn(run func(context.Co
 func (_m *APIClientRequester) DeleteConnector(ctx context.Context, id string) error {
 	ret := _m.Called(ctx, id)
 
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteConnector")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
 		r0 = rf(ctx, id)
@@ -543,6 +643,10 @@ func (_c *APIClientRequester_DeleteConnector_Call) RunAndReturn(run func(context
 // DeleteConnectorToken provides a mock function with given fields: ctx, connectorID, tokenID
 func (_m *APIClientRequester) DeleteConnectorToken(ctx context.Context, connectorID string, tokenID string) error {
 	ret := _m.Called(ctx, connectorID, tokenID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteConnectorToken")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
@@ -588,6 +692,10 @@ func (_c *APIClientRequester_DeleteConnectorToken_Call) RunAndReturn(run func(co
 func (_m *APIClientRequester) DeletePolicy(ctx context.Context, id string) error {
 	ret := _m.Called(ctx, id)
 
+	if len(ret) == 0 {
+		panic("no return value specified for DeletePolicy")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
 		r0 = rf(ctx, id)
@@ -631,6 +739,10 @@ func (_c *APIClientRequester_DeletePolicy_Call) RunAndReturn(run func(context.Co
 func (_m *APIClientRequester) DeleteSocket(ctx context.Context, idOrName string) error {
 	ret := _m.Called(ctx, idOrName)
 
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteSocket")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
 		r0 = rf(ctx, idOrName)
@@ -673,6 +785,10 @@ func (_c *APIClientRequester_DeleteSocket_Call) RunAndReturn(run func(context.Co
 // Policies provides a mock function with given fields: ctx
 func (_m *APIClientRequester) Policies(ctx context.Context) ([]client.Policy, error) {
 	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Policies")
+	}
 
 	var r0 []client.Policy
 	var r1 error
@@ -734,6 +850,10 @@ func (_m *APIClientRequester) PoliciesByNames(ctx context.Context, names ...stri
 	_ca = append(_ca, ctx)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PoliciesByNames")
+	}
 
 	var r0 []client.Policy
 	var r1 error
@@ -797,6 +917,10 @@ func (_c *APIClientRequester_PoliciesByNames_Call) RunAndReturn(run func(context
 func (_m *APIClientRequester) Policy(ctx context.Context, id string) (*client.Policy, error) {
 	ret := _m.Called(ctx, id)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Policy")
+	}
+
 	var r0 *client.Policy
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, string) (*client.Policy, error)); ok {
@@ -852,6 +976,10 @@ func (_c *APIClientRequester_Policy_Call) RunAndReturn(run func(context.Context,
 func (_m *APIClientRequester) RemovePoliciesFromSocket(ctx context.Context, policyIDs []string, socketID string) error {
 	ret := _m.Called(ctx, policyIDs, socketID)
 
+	if len(ret) == 0 {
+		panic("no return value specified for RemovePoliciesFromSocket")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, []string, string) error); ok {
 		r0 = rf(ctx, policyIDs, socketID)
@@ -896,6 +1024,10 @@ func (_c *APIClientRequester_RemovePoliciesFromSocket_Call) RunAndReturn(run fun
 func (_m *APIClientRequester) RemovePolicyFromSocket(ctx context.Context, policyID string, socketID string) error {
 	ret := _m.Called(ctx, policyID, socketID)
 
+	if len(ret) == 0 {
+		panic("no return value specified for RemovePolicyFromSocket")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
 		r0 = rf(ctx, policyID, socketID)
@@ -939,6 +1071,10 @@ func (_c *APIClientRequester_RemovePolicyFromSocket_Call) RunAndReturn(run func(
 // SignSocketKey provides a mock function with given fields: ctx, idOrName, in
 func (_m *APIClientRequester) SignSocketKey(ctx context.Context, idOrName string, in *client.SocketKeyToSign) (*client.SignedSocketKey, error) {
 	ret := _m.Called(ctx, idOrName, in)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SignSocketKey")
+	}
 
 	var r0 *client.SignedSocketKey
 	var r1 error
@@ -996,6 +1132,10 @@ func (_c *APIClientRequester_SignSocketKey_Call) RunAndReturn(run func(context.C
 func (_m *APIClientRequester) Socket(ctx context.Context, idOrName string) (*client.Socket, error) {
 	ret := _m.Called(ctx, idOrName)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Socket")
+	}
+
 	var r0 *client.Socket
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, string) (*client.Socket, error)); ok {
@@ -1050,6 +1190,10 @@ func (_c *APIClientRequester_Socket_Call) RunAndReturn(run func(context.Context,
 // SocketConnectors provides a mock function with given fields: ctx, idOrName
 func (_m *APIClientRequester) SocketConnectors(ctx context.Context, idOrName string) (*client.SocketConnectors, error) {
 	ret := _m.Called(ctx, idOrName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SocketConnectors")
+	}
 
 	var r0 *client.SocketConnectors
 	var r1 error
@@ -1106,6 +1250,10 @@ func (_c *APIClientRequester_SocketConnectors_Call) RunAndReturn(run func(contex
 func (_m *APIClientRequester) SocketUpstreamConfigs(ctx context.Context, idOrName string) (*client.SocketUpstreamConfigs, error) {
 	ret := _m.Called(ctx, idOrName)
 
+	if len(ret) == 0 {
+		panic("no return value specified for SocketUpstreamConfigs")
+	}
+
 	var r0 *client.SocketUpstreamConfigs
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, string) (*client.SocketUpstreamConfigs, error)); ok {
@@ -1161,6 +1309,10 @@ func (_c *APIClientRequester_SocketUpstreamConfigs_Call) RunAndReturn(run func(c
 func (_m *APIClientRequester) Sockets(ctx context.Context) ([]client.Socket, error) {
 	ret := _m.Called(ctx)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Sockets")
+	}
+
 	var r0 []client.Socket
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context) ([]client.Socket, error)); ok {
@@ -1215,6 +1367,10 @@ func (_c *APIClientRequester_Sockets_Call) RunAndReturn(run func(context.Context
 func (_m *APIClientRequester) TokenClaims() (jwt.MapClaims, error) {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for TokenClaims")
+	}
+
 	var r0 jwt.MapClaims
 	var r1 error
 	if rf, ok := ret.Get(0).(func() (jwt.MapClaims, error)); ok {
@@ -1267,6 +1423,10 @@ func (_c *APIClientRequester_TokenClaims_Call) RunAndReturn(run func() (jwt.MapC
 // UpdateConnector provides a mock function with given fields: ctx, in
 func (_m *APIClientRequester) UpdateConnector(ctx context.Context, in *client.Connector) (*client.Connector, error) {
 	ret := _m.Called(ctx, in)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateConnector")
+	}
 
 	var r0 *client.Connector
 	var r1 error
@@ -1322,6 +1482,10 @@ func (_c *APIClientRequester_UpdateConnector_Call) RunAndReturn(run func(context
 // UpdatePolicy provides a mock function with given fields: ctx, id, in
 func (_m *APIClientRequester) UpdatePolicy(ctx context.Context, id string, in *client.Policy) (*client.Policy, error) {
 	ret := _m.Called(ctx, id, in)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdatePolicy")
+	}
 
 	var r0 *client.Policy
 	var r1 error
@@ -1379,6 +1543,10 @@ func (_c *APIClientRequester_UpdatePolicy_Call) RunAndReturn(run func(context.Co
 func (_m *APIClientRequester) UpdateSocket(ctx context.Context, idOrName string, in *client.Socket) (*client.Socket, error) {
 	ret := _m.Called(ctx, idOrName, in)
 
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateSocket")
+	}
+
 	var r0 *client.Socket
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, string, *client.Socket) (*client.Socket, error)); ok {
@@ -1431,13 +1599,12 @@ func (_c *APIClientRequester_UpdateSocket_Call) RunAndReturn(run func(context.Co
 	return _c
 }
 
-type mockConstructorTestingTNewAPIClientRequester interface {
+// NewAPIClientRequester creates a new instance of APIClientRequester. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewAPIClientRequester(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewAPIClientRequester creates a new instance of APIClientRequester. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewAPIClientRequester(t mockConstructorTestingTNewAPIClientRequester) *APIClientRequester {
+}) *APIClientRequester {
 	mock := &APIClientRequester{}
 	mock.Mock.Test(t)
 


### PR DESCRIPTION
## [[ME-2633](https://mysocket.atlassian.net/browse/ME-2633)] Add Special Handling of Retries for 404 Responses 

Adds shorter/faster retries for 404s (where before we wouldn't retry 404s). This is necessary because the Border0 API is replicated across multiple regions and we want to make our SDK more resilient to likely replication lag.


[ME-2633]: https://mysocket.atlassian.net/browse/ME-2633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ