### PR TITLE
[ME-2622] Upstream Service Configuration for VNC Sockets

### DIFF
--- a/client/enum/socket_type.go
+++ b/client/enum/socket_type.go
@@ -6,4 +6,5 @@ const (
 	SocketTypeDatabase = "database" // Database socket type
 	SocketTypeTLS      = "tls"      // TLS socket type
 	SocketTypeTCP      = "tcp"      // TCP socket type
+	SocketTypeVNC      = "vnc"      // VNC socket type
 )

--- a/types/service/vnc_service_configuration.go
+++ b/types/service/vnc_service_configuration.go
@@ -1,0 +1,17 @@
+package service
+
+import "fmt"
+
+// VncServiceConfiguration represents service
+// configuration for vnc services (fka sockets).
+type VncServiceConfiguration struct {
+	HostnameAndPort
+}
+
+// Validate validates the VncServiceConfiguration.
+func (c *VncServiceConfiguration) Validate() error {
+	if err := c.HostnameAndPort.Validate(); err != nil {
+		return fmt.Errorf("invalid hostname or port: %v", err)
+	}
+	return nil
+}

--- a/types/service/vnc_service_configuration_test.go
+++ b/types/service/vnc_service_configuration_test.go
@@ -1,0 +1,40 @@
+package service
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ValidateVncServiceConfiguration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		configuration *VncServiceConfiguration
+		expectedError error
+	}{
+		{
+			name: "Happy case for vnc service",
+			configuration: &VncServiceConfiguration{
+				HostnameAndPort{Hostname: "hello.com", Port: 443},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Should fail for vnc service with invalid hostname/port (missing port)",
+			configuration: &VncServiceConfiguration{
+				HostnameAndPort{Hostname: "hello.com"},
+			},
+			expectedError: fmt.Errorf("invalid hostname or port: port is a required field"),
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, test.expectedError, test.configuration.Validate())
+		})
+	}
+}


### PR DESCRIPTION
## [[ME-2622](https://mysocket.atlassian.net/browse/ME-2622)] Upstream Service Configuration for VNC Sockets

Adds upstream service configuration for new vnc type sockets.

[ME-2622]: https://mysocket.atlassian.net/browse/ME-2622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ