### PR TITLE
[ME-2652] Add missing enum for tcp sockets

### DIFF
--- a/client/enum/socket_type.go
+++ b/client/enum/socket_type.go
@@ -5,4 +5,5 @@ const (
 	SocketTypeSSH      = "ssh"      // SSH socket type
 	SocketTypeDatabase = "database" // Database socket type
 	SocketTypeTLS      = "tls"      // TLS socket type
+	SocketTypeTCP      = "tcp"      // TCP socket type
 )


### PR DESCRIPTION
## [[ME-2652](https://mysocket.atlassian.net/browse/ME-2652)]  Add missing enum for tcp sockets


[ME-2652]: https://mysocket.atlassian.net/browse/ME-2652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ