### PR TITLE
[ME-2656] Upstream Service Configuration for RDP Sockets

### DIFF
--- a/client/enum/socket_type.go
+++ b/client/enum/socket_type.go
@@ -7,4 +7,5 @@ const (
 	SocketTypeTLS      = "tls"      // TLS socket type
 	SocketTypeTCP      = "tcp"      // TCP socket type
 	SocketTypeVNC      = "vnc"      // VNC socket type
+	SocketTypeRDP      = "rdp"      // RDP socket type
 )

--- a/types/service/configuration.go
+++ b/types/service/configuration.go
@@ -24,6 +24,9 @@ const (
 
 	// ServiceTypeVnc is the service type for vnc services (fka sockets).
 	ServiceTypeVnc = "vnc"
+
+	// ServiceTypeRdp is the service type for rdp services (fka sockets).
+	ServiceTypeRdp = "rdp"
 )
 
 // Configuration represents upstream service configuration.
@@ -36,6 +39,7 @@ type Configuration struct {
 	TcpServiceConfiguration      *TcpServiceConfiguration      `json:"tcp_service_configuration,omitempty"`
 	TlsServiceConfiguration      *TlsServiceConfiguration      `json:"tls_service_configuration,omitempty"`
 	VncServiceConfiguration      *VncServiceConfiguration      `json:"vnc_service_configuration,omitempty"`
+	RdpServiceConfiguration      *RdpServiceConfiguration      `json:"rdp_service_configuration,omitempty"`
 }
 
 // Validate validates the Configuration.
@@ -102,6 +106,18 @@ func (c *Configuration) Validate(allowExperimentalFeatures bool) error {
 		}
 		return nil
 
+	case ServiceTypeRdp:
+		if nilcheck.AnyNotNil(allConfigsExcept(c, ServiceTypeRdp)...) {
+			return fmt.Errorf("service configuration for service type \"%s\" can only have %s service configuration defined", ServiceTypeRdp, ServiceTypeRdp)
+		}
+		if c.RdpServiceConfiguration == nil {
+			return fmt.Errorf("service configuration for service type \"%s\" must have %s service configuration defined", ServiceTypeRdp, ServiceTypeRdp)
+		}
+		if err := c.RdpServiceConfiguration.Validate(); err != nil {
+			return fmt.Errorf("invalid %s service configuration: %v", ServiceTypeRdp, err)
+		}
+		return nil
+
 	// deprecated: now referred to as tcp sockets
 	case ServiceTypeTls:
 		if nilcheck.AnyNotNil(allConfigsExcept(c, ServiceTypeTls)) {
@@ -156,6 +172,9 @@ func allConfigsExcept(c *Configuration, svcType string) []any {
 	}
 	if svcType != ServiceTypeVnc {
 		all = append(all, c.VncServiceConfiguration)
+	}
+	if svcType != ServiceTypeRdp {
+		all = append(all, c.RdpServiceConfiguration)
 	}
 
 	return all

--- a/types/service/rdp_service_configuration.go
+++ b/types/service/rdp_service_configuration.go
@@ -1,0 +1,17 @@
+package service
+
+import "fmt"
+
+// RdpServiceConfiguration represents service
+// configuration for rdp services (fka sockets).
+type RdpServiceConfiguration struct {
+	HostnameAndPort
+}
+
+// Validate validates the RdpServiceConfiguration.
+func (c *RdpServiceConfiguration) Validate() error {
+	if err := c.HostnameAndPort.Validate(); err != nil {
+		return fmt.Errorf("invalid hostname or port: %v", err)
+	}
+	return nil
+}

--- a/types/service/rdp_service_configuration_test.go
+++ b/types/service/rdp_service_configuration_test.go
@@ -1,0 +1,40 @@
+package service
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ValidateRdpServiceConfiguration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		configuration *RdpServiceConfiguration
+		expectedError error
+	}{
+		{
+			name: "Happy case for vnc service",
+			configuration: &RdpServiceConfiguration{
+				HostnameAndPort{Hostname: "hello.com", Port: 443},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Should fail for vnc service with invalid hostname/port (missing port)",
+			configuration: &RdpServiceConfiguration{
+				HostnameAndPort{Hostname: "hello.com"},
+			},
+			expectedError: fmt.Errorf("invalid hostname or port: port is a required field"),
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, test.expectedError, test.configuration.Validate())
+		})
+	}
+}


### PR DESCRIPTION
## [[ME-2656](https://mysocket.atlassian.net/browse/ME-2622)] Upstream Service Configuration for RDP Sockets

Adds upstream service configuration for new rdp type sockets.

[ME-2656]: https://mysocket.atlassian.net/browse/ME-2656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ