### PR TITLE
[ME-2657] Upstream Service Configuration for VPN Sockets

### DIFF
--- a/client/enum/socket_type.go
+++ b/client/enum/socket_type.go
@@ -7,5 +7,6 @@ const (
 	SocketTypeTLS      = "tls"      // TLS socket type
 	SocketTypeTCP      = "tcp"      // TCP socket type
 	SocketTypeVNC      = "vnc"      // VNC socket type
+	SocketTypeVPN      = "vpn"      // VPN socket type
 	SocketTypeRDP      = "rdp"      // RDP socket type
 )

--- a/types/service/configuration.go
+++ b/types/service/configuration.go
@@ -25,6 +25,9 @@ const (
 	// ServiceTypeVnc is the service type for vnc services (fka sockets).
 	ServiceTypeVnc = "vnc"
 
+	// ServiceTypeVpn is the service type for vpn services (fka sockets).
+	ServiceTypeVpn = "vpn"
+
 	// ServiceTypeRdp is the service type for rdp services (fka sockets).
 	ServiceTypeRdp = "rdp"
 )
@@ -39,6 +42,7 @@ type Configuration struct {
 	TcpServiceConfiguration      *TcpServiceConfiguration      `json:"tcp_service_configuration,omitempty"`
 	TlsServiceConfiguration      *TlsServiceConfiguration      `json:"tls_service_configuration,omitempty"`
 	VncServiceConfiguration      *VncServiceConfiguration      `json:"vnc_service_configuration,omitempty"`
+	VpnServiceConfiguration      *VpnServiceConfiguration      `json:"vpn_service_configuration,omitempty"`
 	RdpServiceConfiguration      *RdpServiceConfiguration      `json:"rdp_service_configuration,omitempty"`
 }
 
@@ -103,6 +107,18 @@ func (c *Configuration) Validate(allowExperimentalFeatures bool) error {
 		}
 		if err := c.VncServiceConfiguration.Validate(); err != nil {
 			return fmt.Errorf("invalid %s service configuration: %v", ServiceTypeVnc, err)
+		}
+		return nil
+
+	case ServiceTypeVpn:
+		if nilcheck.AnyNotNil(allConfigsExcept(c, ServiceTypeVpn)...) {
+			return fmt.Errorf("service configuration for service type \"%s\" can only have %s service configuration defined", ServiceTypeVpn, ServiceTypeVpn)
+		}
+		if c.VpnServiceConfiguration == nil {
+			return fmt.Errorf("service configuration for service type \"%s\" must have %s service configuration defined", ServiceTypeVpn, ServiceTypeVpn)
+		}
+		if err := c.VpnServiceConfiguration.Validate(); err != nil {
+			return fmt.Errorf("invalid %s service configuration: %v", ServiceTypeVpn, err)
 		}
 		return nil
 
@@ -172,6 +188,9 @@ func allConfigsExcept(c *Configuration, svcType string) []any {
 	}
 	if svcType != ServiceTypeVnc {
 		all = append(all, c.VncServiceConfiguration)
+	}
+	if svcType != ServiceTypeVpn {
+		all = append(all, c.VpnServiceConfiguration)
 	}
 	if svcType != ServiceTypeRdp {
 		all = append(all, c.RdpServiceConfiguration)

--- a/types/service/vpn_service_configuration.go
+++ b/types/service/vpn_service_configuration.go
@@ -1,0 +1,30 @@
+package service
+
+import (
+	"fmt"
+
+	"github.com/borderzero/border0-go/lib/types/netaddr"
+)
+
+// VpnServiceConfiguration represents service
+// configuration for vpn services (fka sockets).
+type VpnServiceConfiguration struct {
+	VpnSubnet string   `json:"vpn_subnet"`
+	Routes    []string `json:"routes,omitempty"`
+}
+
+// Validate validates the VpnServiceConfiguration.
+func (c *VpnServiceConfiguration) Validate() error {
+	if c.VpnSubnet == "" {
+		return fmt.Errorf("vpn_subnet is a required field")
+	}
+	if !netaddr.IsCIDRv4(c.VpnSubnet) {
+		return fmt.Errorf("vpn_subnet \"%s\" is not valid IPv4 CIDR notation", c.VpnSubnet)
+	}
+	for i, route := range c.Routes {
+		if !netaddr.IsCIDRv4(route) {
+			return fmt.Errorf("routes[%d] (\"%s\") is not valid IPv4 CIDR notation", i, route)
+		}
+	}
+	return nil
+}

--- a/types/service/vpn_service_configuration_test.go
+++ b/types/service/vpn_service_configuration_test.go
@@ -1,0 +1,58 @@
+package service
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ValidateVpnServiceConfiguration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		configuration *VpnServiceConfiguration
+		expectedError error
+	}{
+		{
+			name: "Should succeed when vpn subnet and routes are valid",
+			configuration: &VpnServiceConfiguration{
+				VpnSubnet: "10.0.0.0/24",
+				Routes:    []string{"10.0.0.0/8"},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Should fail when vpn subnet is not valid cidr",
+			configuration: &VpnServiceConfiguration{
+				VpnSubnet: "10.0.0.0",
+				Routes:    []string{"10.0.0.0/8"},
+			},
+			expectedError: fmt.Errorf("vpn_subnet \"%s\" is not valid IPv4 CIDR notation", "10.0.0.0"),
+		},
+		{
+			name: "Should fail when routes contains invalid cidr in index 0",
+			configuration: &VpnServiceConfiguration{
+				VpnSubnet: "10.0.0.0/24",
+				Routes:    []string{"10.0.0.0"},
+			},
+			expectedError: fmt.Errorf("routes[%d] (\"%s\") is not valid IPv4 CIDR notation", 0, "10.0.0.0"),
+		},
+		{
+			name: "Should fail when routes contains invalid cidr in index non-zero",
+			configuration: &VpnServiceConfiguration{
+				VpnSubnet: "10.0.0.0/24",
+				Routes:    []string{"192.168.0.0/24", "10.0.0.0"},
+			},
+			expectedError: fmt.Errorf("routes[%d] (\"%s\") is not valid IPv4 CIDR notation", 1, "10.0.0.0"),
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, test.expectedError, test.configuration.Validate())
+		})
+	}
+}


### PR DESCRIPTION
## [[ME-2657](https://mysocket.atlassian.net/browse/ME-2657)] Upstream Service Configuration for VPN Sockets

Adds upstream service configuration for new vpn type sockets.

[ME-2657]: https://mysocket.atlassian.net/browse/ME-2657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ