### PR TITLE
[ME-2608] Add method Equals(Set[T]) to set type

### DIFF
--- a/lib/types/set/concurrencysafe.go
+++ b/lib/types/set/concurrencysafe.go
@@ -88,3 +88,19 @@ func (s *ConcurrencySafeSet[T]) Size() int {
 
 	return s.inner.Size()
 }
+
+// Equals returns true if a given set is equal (has the same elements).
+func (s *ConcurrencySafeSet[T]) Equals(comp Set[T]) bool {
+	// must check if both sets reference the same
+	// object, otherwise deadlock is possible.
+	if concurrencySafeSetB, sameType := comp.(*ConcurrencySafeSet[T]); sameType {
+		if s == concurrencySafeSetB {
+			return true
+		}
+	}
+
+	s.Lock()
+	defer s.Unlock()
+
+	return s.inner.Equals(comp)
+}

--- a/lib/types/set/concurrencysafe_test.go
+++ b/lib/types/set/concurrencysafe_test.go
@@ -387,3 +387,52 @@ func Test_ConcurrencySafeSetSize(t *testing.T) {
 		})
 	}
 }
+
+func Test_ConcurrencySafeSetEquals(t *testing.T) {
+	t.Parallel()
+
+	mockElemA := "a"
+	mockElemB := "b"
+
+	testCCSet := NewConcurrencySafe(mockElemA)
+
+	tests := []struct {
+		name string
+		seta *ConcurrencySafeSet[string]
+		setb *ConcurrencySafeSet[string]
+		eq   bool
+	}{
+		{
+			name: "Empty sets should be equal",
+			seta: NewConcurrencySafe[string](),
+			setb: NewConcurrencySafe[string](),
+			eq:   true,
+		},
+		{
+			name: "Sets with equal elements should be equal",
+			seta: NewConcurrencySafe[string](mockElemA),
+			setb: NewConcurrencySafe[string](mockElemA),
+			eq:   true,
+		},
+		{
+			name: "Sets with different elements should not be equal",
+			seta: NewConcurrencySafe[string](mockElemA),
+			setb: NewConcurrencySafe[string](mockElemB),
+			eq:   false,
+		},
+		{
+			name: "Comparing against self should be equal (and not deadlock)",
+			seta: testCCSet,
+			setb: testCCSet,
+			eq:   true,
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, test.seta.Equals(test.setb), test.eq)
+		})
+	}
+}

--- a/lib/types/set/set.go
+++ b/lib/types/set/set.go
@@ -9,4 +9,5 @@ type Set[T comparable] interface {
 	Copy() Set[T]
 	Slice() []T
 	Size() int
+	Equals(Set[T]) bool
 }

--- a/lib/types/set/simple.go
+++ b/lib/types/set/simple.go
@@ -63,3 +63,18 @@ func (s SimpleSet[T]) Slice() []T {
 func (s SimpleSet[T]) Size() int {
 	return len(s)
 }
+
+// Equals returns true if a given set is equal (has the same elements).
+func (s SimpleSet[T]) Equals(comp Set[T]) bool {
+	if s.Size() != comp.Size() {
+		return false
+	}
+
+	for k := range s {
+		if !comp.Has(k) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/lib/types/set/simple_test.go
+++ b/lib/types/set/simple_test.go
@@ -379,3 +379,44 @@ func Test_SimpleSetSize(t *testing.T) {
 		})
 	}
 }
+
+func Test_SimpleSetEquals(t *testing.T) {
+	t.Parallel()
+
+	mockElemA := "a"
+	mockElemB := "b"
+
+	tests := []struct {
+		name string
+		seta SimpleSet[string]
+		setb SimpleSet[string]
+		eq   bool
+	}{
+		{
+			name: "Empty sets should be equal",
+			seta: New[string](),
+			setb: New[string](),
+			eq:   true,
+		},
+		{
+			name: "Sets with equal elements should be equal",
+			seta: New[string](mockElemA),
+			setb: New[string](mockElemA),
+			eq:   true,
+		},
+		{
+			name: "Sets with different elements should not be equal",
+			seta: New[string](mockElemA),
+			setb: New[string](mockElemB),
+			eq:   false,
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, test.seta.Equals(test.setb), test.eq)
+		})
+	}
+}


### PR DESCRIPTION
## [[ME-2608](https://mysocket.atlassian.net/browse/ME-2608)] Add method Equals(Set[T]) to set type

Need our set types to have an equality method... need it for a change in the API.

[ME-2608]: https://mysocket.atlassian.net/browse/ME-2608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ