### PR TITLE
[ME-2657] Improve VPN Socket Upstream Config Field Names

### DIFF
--- a/types/service/vpn_service_configuration.go
+++ b/types/service/vpn_service_configuration.go
@@ -9,21 +9,21 @@ import (
 // VpnServiceConfiguration represents service
 // configuration for vpn services (fka sockets).
 type VpnServiceConfiguration struct {
-	VpnSubnet string   `json:"vpn_subnet"`
-	Routes    []string `json:"routes,omitempty"`
+	DHCPPoolSubnet   string   `json:"dhcp_pool_subnet"`
+	AdvertisedRoutes []string `json:"advertised_routes,omitempty"`
 }
 
 // Validate validates the VpnServiceConfiguration.
 func (c *VpnServiceConfiguration) Validate() error {
-	if c.VpnSubnet == "" {
-		return fmt.Errorf("vpn_subnet is a required field")
+	if c.DHCPPoolSubnet == "" {
+		return fmt.Errorf("dhcp_pool_subnet is a required field")
 	}
-	if !netaddr.IsCIDRv4(c.VpnSubnet) {
-		return fmt.Errorf("vpn_subnet \"%s\" is not valid IPv4 CIDR notation", c.VpnSubnet)
+	if !netaddr.IsCIDRv4(c.DHCPPoolSubnet) {
+		return fmt.Errorf("dhcp_pool_subnet \"%s\" is not valid IPv4 CIDR notation", c.DHCPPoolSubnet)
 	}
-	for i, route := range c.Routes {
+	for i, route := range c.AdvertisedRoutes {
 		if !netaddr.IsCIDRv4(route) {
-			return fmt.Errorf("routes[%d] (\"%s\") is not valid IPv4 CIDR notation", i, route)
+			return fmt.Errorf("advertised_routes[%d] (\"%s\") is not valid IPv4 CIDR notation", i, route)
 		}
 	}
 	return nil

--- a/types/service/vpn_service_configuration_test.go
+++ b/types/service/vpn_service_configuration_test.go
@@ -18,34 +18,34 @@ func Test_ValidateVpnServiceConfiguration(t *testing.T) {
 		{
 			name: "Should succeed when vpn subnet and routes are valid",
 			configuration: &VpnServiceConfiguration{
-				VpnSubnet: "10.0.0.0/24",
-				Routes:    []string{"10.0.0.0/8"},
+				DHCPPoolSubnet:   "10.0.0.0/24",
+				AdvertisedRoutes: []string{"10.0.0.0/8"},
 			},
 			expectedError: nil,
 		},
 		{
 			name: "Should fail when vpn subnet is not valid cidr",
 			configuration: &VpnServiceConfiguration{
-				VpnSubnet: "10.0.0.0",
-				Routes:    []string{"10.0.0.0/8"},
+				DHCPPoolSubnet:   "10.0.0.0",
+				AdvertisedRoutes: []string{"10.0.0.0/8"},
 			},
-			expectedError: fmt.Errorf("vpn_subnet \"%s\" is not valid IPv4 CIDR notation", "10.0.0.0"),
+			expectedError: fmt.Errorf("dhcp_pool_subnet \"%s\" is not valid IPv4 CIDR notation", "10.0.0.0"),
 		},
 		{
 			name: "Should fail when routes contains invalid cidr in index 0",
 			configuration: &VpnServiceConfiguration{
-				VpnSubnet: "10.0.0.0/24",
-				Routes:    []string{"10.0.0.0"},
+				DHCPPoolSubnet:   "10.0.0.0/24",
+				AdvertisedRoutes: []string{"10.0.0.0"},
 			},
-			expectedError: fmt.Errorf("routes[%d] (\"%s\") is not valid IPv4 CIDR notation", 0, "10.0.0.0"),
+			expectedError: fmt.Errorf("advertised_routes[%d] (\"%s\") is not valid IPv4 CIDR notation", 0, "10.0.0.0"),
 		},
 		{
 			name: "Should fail when routes contains invalid cidr in index non-zero",
 			configuration: &VpnServiceConfiguration{
-				VpnSubnet: "10.0.0.0/24",
-				Routes:    []string{"192.168.0.0/24", "10.0.0.0"},
+				DHCPPoolSubnet:   "10.0.0.0/24",
+				AdvertisedRoutes: []string{"192.168.0.0/24", "10.0.0.0"},
 			},
-			expectedError: fmt.Errorf("routes[%d] (\"%s\") is not valid IPv4 CIDR notation", 1, "10.0.0.0"),
+			expectedError: fmt.Errorf("advertised_routes[%d] (\"%s\") is not valid IPv4 CIDR notation", 1, "10.0.0.0"),
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
## [[ME-2657](https://mysocket.atlassian.net/browse/ME-2657)] Improve VPN Socket Upstream Config Field Names

Had a long chat with chatGPT to come up with more explicit/straightforward field names.

`VpnSubnet` --> `DHCPPoolSubnetV4`
`Routes`  --> `AdvertisedRoutesV4`

[ME-2657]: https://mysocket.atlassian.net/browse/ME-2657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ