### PR TITLE
[ME-2810] Add DNS Name as Socket Output Field

### DIFF
--- a/client/socket.go
+++ b/client/socket.go
@@ -128,6 +128,9 @@ type Socket struct {
 
 	// associated policies
 	Policies []Policy `json:"policies,omitempty"`
+
+	// output fields
+	DNS string `json:"dnsname,omitempty"`
 }
 
 // SocketConnectors represents a list of connectors that are linked to a socket.


### PR DESCRIPTION
## [[ME-2810](https://mysocket.atlassian.net/browse/ME-2810)] Add DNS Name as Socket Output Field

[ME-2810]: https://mysocket.atlassian.net/browse/ME-2810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ