### PR TITLE
[ME-2810] Downgrade Go to Latest-1 (1.21)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/borderzero/border0-go
 
-go 1.22
+go 1.21
 
 require (
 	github.com/cenkalti/backoff/v4 v4.2.1


### PR DESCRIPTION
## [[ME-2810](https://mysocket.atlassian.net/browse/ME-2810)] Downgrade Go to Latest-1 (1.21)

See https://github.com/srl-labs/containerlab/pull/1990 (specifically https://github.com/srl-labs/containerlab/pull/1990#discussion_r1563978247) -- in this case containerlab would have to upgrade their version of go in order to use *this* package.

It is a good idea to use `goN-1` version for broader adoption and allow SDK users to upgrade their version of Go before we do here. 

[ME-2810]: https://mysocket.atlassian.net/browse/ME-2810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ