### PR TITLE
[ME-3028] Add IAM Users, IAM Groups, and Service Accounts

### DIFF
--- a/client/api_client.go
+++ b/client/api_client.go
@@ -30,6 +30,9 @@ type Requester interface {
 	SocketService
 	ConnectorService
 	PolicyService
+	UserService
+	GroupService
+	ServiceAccountService
 }
 
 const (

--- a/client/group.go
+++ b/client/group.go
@@ -1,0 +1,75 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// GroupService is an interface for API client methods that interact with Border0 API to manage groups.
+type GroupService interface {
+	Group(ctx context.Context, id string) (out *Group, err error)
+	CreateGroup(ctx context.Context, in *Group) (out *Group, err error)
+	UpdateGroup(ctx context.Context, in *Group) (out *Group, err error)
+	DeleteGroup(ctx context.Context, id string) (err error)
+}
+
+// Group fetches a group from your Border0 organization by UUID. Group UUID is globally unique and immutable.
+func (api *APIClient) Group(ctx context.Context, id string) (out *Group, err error) {
+	out = new(Group)
+	_, err = api.request(ctx, http.MethodGet, fmt.Sprintf("/organizations/iam/groups/%s", id), nil, out)
+	if err != nil {
+		if NotFound(err) {
+			return nil, fmt.Errorf("group with ID [%s] not found: %w", id, err)
+		}
+		return nil, err
+	}
+	return out, nil
+}
+
+// CreateGroup creates a new group in your Border0 organization.
+func (api *APIClient) CreateGroup(ctx context.Context, in *Group) (out *Group, err error) {
+	out = new(Group)
+	_, err = api.request(ctx, http.MethodPost, "/organizations/iam/groups", in, out)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// UpdateGroup updates an existing group in your Border0 organization.
+func (api *APIClient) UpdateGroup(ctx context.Context, in *Group) (out *Group, err error) {
+	out = new(Group)
+	_, err = api.request(ctx, http.MethodPut, "/organizations/iam/groups", in, out)
+	if err != nil {
+		if NotFound(err) {
+			return nil, fmt.Errorf("group with ID [%s] not found: %w", in.ID, err)
+		}
+		return nil, err
+	}
+	return out, nil
+}
+
+// DeleteGroup deletes an existing group from your Border0 organization.
+func (api *APIClient) DeleteGroup(ctx context.Context, id string) (err error) {
+	_, err = api.request(ctx, http.MethodDelete, fmt.Sprintf("/organizations/iam/groups/%s", id), nil, nil)
+	if err != nil {
+		if NotFound(err) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+// Group represents a group in your Border0 organization.
+type Group struct {
+	// input fields
+	DisplayName string `json:"display_name"`
+
+	// output fields
+	ID               string            `json:"id"`
+	GroupType        string            `json:"group_type"`
+	DirectoryService *DirectoryService `json:"directory_service,omitempty"`
+	Members          []User            `json:"members,omitempty"`
+}

--- a/client/group_test.go
+++ b/client/group_test.go
@@ -1,0 +1,302 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/borderzero/border0-go/client/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func Test_APIClient_Group(t *testing.T) {
+	t.Parallel()
+
+	testGroup := &Group{
+		DisplayName: "Test description",
+		ID:          "test-id",
+	}
+
+	tests := []struct {
+		name          string
+		mockRequester func(context.Context, *mocks.ClientHTTPRequester)
+		givenID       string
+		wantGroup     *Group
+		wantErr       error
+	}{
+		{
+			name: "failed to get group",
+			mockRequester: func(ctx context.Context, requester *mocks.ClientHTTPRequester) {
+				requester.EXPECT().
+					Request(ctx, http.MethodGet, fmt.Sprintf("%s/organizations/iam/groups/%s", defaultBaseURL, "test-id"), nil, new(Group)).
+					Return(http.StatusBadRequest, errors.New("failed to get group"))
+			},
+			givenID:   "test-id",
+			wantGroup: nil,
+			wantErr:   errors.New("failed after 1 attempt: failed to get group"),
+		},
+		{
+			name: "404 not found error returned, let's make sure we wrap the error with more info",
+			mockRequester: func(ctx context.Context, requester *mocks.ClientHTTPRequester) {
+				requester.EXPECT().
+					Request(ctx, http.MethodGet, fmt.Sprintf("%s/organizations/iam/groups/%s", defaultBaseURL, "test-id"), nil, new(Group)).
+					Return(http.StatusNotFound, Error{Code: http.StatusNotFound, Message: "group not found"})
+			},
+			givenID: "test-id",
+			wantErr: errors.New("group with ID [test-id] not found: failed after 4 attempts: 404: group not found"),
+		},
+		{
+			name: "happy path",
+			mockRequester: func(ctx context.Context, requester *mocks.ClientHTTPRequester) {
+				// have to use On() instead of EXPECT() because we need to set the output
+				// and the Run() function would raise nil pointer panic if we use it with
+				// EXPECT()
+				requester.On("Request", ctx, http.MethodGet, fmt.Sprintf("%s/organizations/iam/groups/%s", defaultBaseURL, "test-id"), nil, new(Group)).
+					Return(http.StatusOK, nil).
+					Run(func(args mock.Arguments) {
+						output := args.Get(4).(*Group)
+						*output = *testGroup
+					})
+			},
+			givenID:   "test-id",
+			wantGroup: testGroup,
+			wantErr:   nil,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			requester := new(mocks.ClientHTTPRequester)
+			test.mockRequester(ctx, requester)
+
+			api := New(
+				WithRetryMax(0),
+			)
+			api.http = requester
+
+			gotGroup, gotErr := api.Group(ctx, test.givenID)
+
+			if test.wantErr == nil {
+				assert.NoError(t, gotErr)
+			} else {
+				assert.EqualError(t, gotErr, test.wantErr.Error())
+			}
+			assert.Equal(t, test.wantGroup, gotGroup)
+		})
+	}
+}
+
+func Test_APIClient_CreateGroup(t *testing.T) {
+	t.Parallel()
+
+	testGroupInput := &Group{
+		DisplayName: "Test description",
+	}
+
+	testGroupOutput := &Group{
+		DisplayName: "Test description",
+		ID:          "test-id",
+	}
+
+	tests := []struct {
+		name          string
+		mockRequester func(context.Context, *mocks.ClientHTTPRequester)
+		givenGroup    *Group
+		wantGroup     *Group
+		wantErr       error
+	}{
+		{
+			name: "failed to create connector",
+			mockRequester: func(ctx context.Context, requester *mocks.ClientHTTPRequester) {
+				requester.EXPECT().
+					Request(ctx, http.MethodPost, fmt.Sprintf("%s/organizations/iam/groups", defaultBaseURL), testGroupInput, new(Group)).
+					Return(http.StatusBadRequest, errors.New("failed to create group"))
+			},
+			givenGroup: testGroupInput,
+			wantGroup:  nil,
+			wantErr:    errors.New("failed after 1 attempt: failed to create group"),
+		},
+		{
+			name: "happy path",
+			mockRequester: func(ctx context.Context, requester *mocks.ClientHTTPRequester) {
+				requester.EXPECT().
+					Request(ctx, http.MethodPost, fmt.Sprintf("%s/organizations/iam/groups", defaultBaseURL), testGroupInput, new(Group)).
+					Return(http.StatusOK, nil).
+					Run(func(_ context.Context, _, _ string, _, output any) {
+						group := output.(*Group)
+						*group = *testGroupOutput
+					})
+			},
+			givenGroup: testGroupInput,
+			wantGroup:  testGroupOutput,
+			wantErr:    nil,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			requester := new(mocks.ClientHTTPRequester)
+			test.mockRequester(ctx, requester)
+
+			api := New(
+				WithRetryMax(0),
+			)
+			api.http = requester
+
+			gotGroup, gotErr := api.CreateGroup(ctx, test.givenGroup)
+
+			if test.wantErr == nil {
+				assert.NoError(t, gotErr)
+			} else {
+				assert.EqualError(t, gotErr, test.wantErr.Error())
+			}
+			assert.Equal(t, test.wantGroup, gotGroup)
+		})
+	}
+}
+
+func Test_APIClient_UpdateGroup(t *testing.T) {
+	t.Parallel()
+
+	testGroup := &Group{
+		DisplayName: "Test description",
+		ID:          "test-id",
+	}
+
+	tests := []struct {
+		name          string
+		mockRequester func(context.Context, *mocks.ClientHTTPRequester)
+		givenGroup    *Group
+		wantGroup     *Group
+		wantErr       error
+	}{
+		{
+			name: "failed to update group",
+			mockRequester: func(ctx context.Context, requester *mocks.ClientHTTPRequester) {
+				requester.EXPECT().
+					Request(ctx, http.MethodPut, fmt.Sprintf("%s/organizations/iam/groups", defaultBaseURL), testGroup, new(Group)).
+					Return(http.StatusBadRequest, errors.New("failed to update group"))
+			},
+			givenGroup: testGroup,
+			wantGroup:  nil,
+			wantErr:    errors.New("failed after 1 attempt: failed to update group"),
+		},
+		{
+			name: "happy path",
+			mockRequester: func(ctx context.Context, requester *mocks.ClientHTTPRequester) {
+				requester.EXPECT().
+					Request(ctx, http.MethodPut, fmt.Sprintf("%s/organizations/iam/groups", defaultBaseURL), testGroup, new(Group)).
+					Return(http.StatusOK, nil).
+					Run(func(_ context.Context, _, _ string, _, output any) {
+						group := output.(*Group)
+						*group = *testGroup
+					})
+			},
+			givenGroup: testGroup,
+			wantGroup:  testGroup,
+			wantErr:    nil,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			requester := new(mocks.ClientHTTPRequester)
+			test.mockRequester(ctx, requester)
+
+			api := New(
+				WithRetryMax(0),
+			)
+			api.http = requester
+
+			gotGroup, gotErr := api.UpdateGroup(ctx, test.givenGroup)
+
+			if test.wantErr == nil {
+				assert.NoError(t, gotErr)
+			} else {
+				assert.EqualError(t, gotErr, test.wantErr.Error())
+			}
+			assert.Equal(t, test.wantGroup, gotGroup)
+		})
+	}
+}
+
+func Test_APIClient_DeleteGroup(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		mockRequester func(context.Context, *mocks.ClientHTTPRequester)
+		givenID       string
+		wantErr       error
+	}{
+		{
+			name: "failed to delete group",
+			mockRequester: func(ctx context.Context, requester *mocks.ClientHTTPRequester) {
+				requester.EXPECT().
+					Request(ctx, http.MethodDelete, fmt.Sprintf("%s/organizations/iam/groups/%s", defaultBaseURL, "test-id"), nil, nil).
+					Return(http.StatusBadRequest, errors.New("failed to delete group"))
+			},
+			givenID: "test-id",
+			wantErr: errors.New("failed after 1 attempt: failed to delete group"),
+		},
+		{
+			name: "404 not found error returned, but we will ignore it and return nil",
+			mockRequester: func(ctx context.Context, requester *mocks.ClientHTTPRequester) {
+				requester.EXPECT().
+					Request(ctx, http.MethodDelete, fmt.Sprintf("%s/organizations/iam/groups/%s", defaultBaseURL, "test-id"), nil, nil).
+					Return(http.StatusNotFound, Error{Code: http.StatusNotFound, Message: "group not found"})
+			},
+			givenID: "test-id",
+			wantErr: nil,
+		},
+		{
+			name: "happy path",
+			mockRequester: func(ctx context.Context, requester *mocks.ClientHTTPRequester) {
+				requester.EXPECT().
+					Request(ctx, http.MethodDelete, fmt.Sprintf("%s/organizations/iam/groups/%s", defaultBaseURL, "test-id"), nil, nil).
+					Return(http.StatusOK, nil)
+			},
+			givenID: "test-id",
+			wantErr: nil,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			requester := new(mocks.ClientHTTPRequester)
+			test.mockRequester(ctx, requester)
+
+			api := New(
+				WithRetryMax(0),
+			)
+			api.http = requester
+
+			gotErr := api.DeleteGroup(ctx, test.givenID)
+
+			if test.wantErr == nil {
+				assert.NoError(t, gotErr)
+			} else {
+				assert.EqualError(t, gotErr, test.wantErr.Error())
+			}
+		})
+	}
+}

--- a/client/service_account.go
+++ b/client/service_account.go
@@ -1,0 +1,117 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// ServiceAccountService is an interface for API client methods that interact with Border0 API to manage service accounts.
+type ServiceAccountService interface {
+	ServiceAccount(ctx context.Context, name string) (out *ServiceAccount, err error)
+	CreateServiceAccount(ctx context.Context, in *ServiceAccount) (out *ServiceAccount, err error)
+	UpdateServiceAccount(ctx context.Context, in *ServiceAccount) (out *ServiceAccount, err error)
+	DeleteServiceAccount(ctx context.Context, id string) (err error)
+	CreateServiceAccountToken(ctx context.Context, serviceAccountName string, in *ServiceAccountToken) (out *ServiceAccountToken, err error)
+	DeleteServiceAccountToken(ctx context.Context, serviceAccountName, tokenID string) (err error)
+}
+
+// ServiceAccount fetches a service account from your Border0 organization
+// by name. Service Account name must be unique and immutable.
+func (api *APIClient) ServiceAccount(ctx context.Context, name string) (out *ServiceAccount, err error) {
+	out = new(ServiceAccount)
+	_, err = api.request(ctx, http.MethodGet, fmt.Sprintf("/organizations/iam/service_accounts/%s", name), nil, out)
+	if err != nil {
+		if NotFound(err) {
+			return nil, fmt.Errorf("service account with name [%s] not found: %w", name, err)
+		}
+		return nil, err
+	}
+	return out, nil
+}
+
+// CreateServiceAccount creates a new service account in your Border0 organization. Service
+// Account name must be in slug format (alphanumeric and dashes) and be unique in the organization.
+func (api *APIClient) CreateServiceAccount(ctx context.Context, in *ServiceAccount) (out *ServiceAccount, err error) {
+	out = new(ServiceAccount)
+	_, err = api.request(ctx, http.MethodPost, "/organizations/iam/service_accounts", in, out)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// UpdateServiceAccount updates an existing service account in your Border0 organization.
+func (api *APIClient) UpdateServiceAccount(ctx context.Context, in *ServiceAccount) (out *ServiceAccount, err error) {
+	out = new(ServiceAccount)
+	_, err = api.request(ctx, http.MethodPut, fmt.Sprintf("/organizations/iam/service_accounts/%s", in.Name), in, out)
+	if err != nil {
+		if NotFound(err) {
+			return nil, fmt.Errorf("service account with name [%s] not found: %w", in.Name, err)
+		}
+		return nil, err
+	}
+	return out, nil
+}
+
+// DeleteServiceAccount deletes an existing service account from your Border0 organization.
+func (api *APIClient) DeleteServiceAccount(ctx context.Context, name string) (err error) {
+	_, err = api.request(ctx, http.MethodDelete, fmt.Sprintf("/organizations/iam/service_accounts/%s", name), nil, nil)
+	if err != nil {
+		if NotFound(err) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+// CreateServiceAccountToken creates a new token for a service account. The token is used to authenticate connector with the
+// Border0 API. The token can be created with or without a expiration date. If ExpiresAt field is not set, token will not expire.
+func (api *APIClient) CreateServiceAccountToken(ctx context.Context, serviceAccountName string, in *ServiceAccountToken) (out *ServiceAccountToken, err error) {
+	out = new(ServiceAccountToken)
+	_, err = api.request(ctx, http.MethodPost, fmt.Sprintf("/organizations/iam/service_accounts/%s/tokens", serviceAccountName), in, out)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// DeleteServiceAccountToken deletes a token for a service account by service account name and token UUID.
+func (api *APIClient) DeleteServiceAccountToken(ctx context.Context, serviceAccountName, tokenID string) (err error) {
+	_, err = api.request(ctx, http.MethodDelete, fmt.Sprintf("/organizations/iam/service_accounts/%s/tokens/%s", serviceAccountName, tokenID), nil, nil)
+	if err != nil {
+		if NotFound(err) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+// ServiceAccount represents a service account in your Border0 organization.
+type ServiceAccount struct {
+	// input fields
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Role        string `json:"role"`
+	Active      bool   `json:"active"`
+
+	// output fields
+	ID         string       `json:"service_account_id"`
+	CreatedAt  FlexibleTime `json:"created_at"`
+	UpdatedAt  FlexibleTime `json:"updated_at"`
+	LastSeenAt FlexibleTime `json:"last_seen_at,omitempty"`
+}
+
+// ServiceAccountToken represents a service account token in your Border0 organization.
+type ServiceAccountToken struct {
+	// input fields
+	Name      string       `json:"name"`
+	ExpiresAt FlexibleTime `json:"expires_at,omitempty"`
+
+	// output fields
+	ID        string       `json:"id"`
+	Token     string       `json:"token"`
+	CreatedAt FlexibleTime `json:"created_at"`
+}

--- a/client/service_account_test.go
+++ b/client/service_account_test.go
@@ -1,0 +1,474 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/borderzero/border0-go/client/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_APIClient_ServiceAccount(t *testing.T) {
+	t.Parallel()
+
+	testServiceAccount := &ServiceAccount{
+		Name:        "test-name",
+		Description: "Test description",
+		Role:        "admin",
+		ID:          "test-id",
+	}
+
+	tests := []struct {
+		name               string
+		mockRequester      func(context.Context, *mocks.ClientHTTPRequester)
+		givenName          string
+		wantServiceAccount *ServiceAccount
+		wantErr            error
+	}{
+		{
+			name: "failed to get service account",
+			mockRequester: func(ctx context.Context, requester *mocks.ClientHTTPRequester) {
+				requester.EXPECT().
+					Request(ctx, http.MethodGet, fmt.Sprintf("%s/organizations/iam/service_accounts/%s", defaultBaseURL, "test-name"), nil, new(ServiceAccount)).
+					Return(http.StatusBadRequest, errors.New("failed to get service account"))
+			},
+			givenName:          "test-name",
+			wantServiceAccount: nil,
+			wantErr:            errors.New("failed after 1 attempt: failed to get service account"),
+		},
+		{
+			name: "404 not found error returned, let's make sure we wrap the error with more info",
+			mockRequester: func(ctx context.Context, requester *mocks.ClientHTTPRequester) {
+				requester.EXPECT().
+					Request(ctx, http.MethodGet, fmt.Sprintf("%s/organizations/iam/service_accounts/%s", defaultBaseURL, "test-name"), nil, new(ServiceAccount)).
+					Return(http.StatusNotFound, Error{Code: http.StatusNotFound, Message: "service account not found"})
+			},
+			givenName: "test-name",
+			wantErr:   errors.New("service account with name [test-name] not found: failed after 4 attempts: 404: service account not found"),
+		},
+		{
+			name: "happy path",
+			mockRequester: func(ctx context.Context, requester *mocks.ClientHTTPRequester) {
+				// have to use On() instead of EXPECT() because we need to set the output
+				// and the Run() function would raise nil pointer panic if we use it with
+				// EXPECT()
+				requester.On("Request", ctx, http.MethodGet, fmt.Sprintf("%s/organizations/iam/service_accounts/%s", defaultBaseURL, "test-name"), nil, new(ServiceAccount)).
+					Return(http.StatusOK, nil).
+					Run(func(args mock.Arguments) {
+						output := args.Get(4).(*ServiceAccount)
+						*output = *testServiceAccount
+					})
+			},
+			givenName:          "test-name",
+			wantServiceAccount: testServiceAccount,
+			wantErr:            nil,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			requester := new(mocks.ClientHTTPRequester)
+			test.mockRequester(ctx, requester)
+
+			api := New(
+				WithRetryMax(0),
+			)
+			api.http = requester
+
+			gotServiceAccount, gotErr := api.ServiceAccount(ctx, test.givenName)
+
+			if test.wantErr == nil {
+				assert.NoError(t, gotErr)
+			} else {
+				assert.EqualError(t, gotErr, test.wantErr.Error())
+			}
+			assert.Equal(t, test.wantServiceAccount, gotServiceAccount)
+		})
+	}
+}
+
+func Test_APIClient_CreateServiceAccount(t *testing.T) {
+	t.Parallel()
+
+	timestamp, err := FlexibleTimeFrom("2020-01-01T00:00:00Z")
+	require.NoError(t, err)
+
+	testServiceAccountInput := &ServiceAccount{
+		Name:        "test-name",
+		Description: "Test description",
+		Role:        "admin",
+		Active:      true,
+	}
+	testServiceAccountOutput := &ServiceAccount{
+		Name:        "test-name",
+		Description: "Test description",
+		Role:        "admin",
+		Active:      true,
+		ID:          "test-id",
+		CreatedAt:   timestamp,
+		UpdatedAt:   timestamp,
+		LastSeenAt:  timestamp,
+	}
+
+	tests := []struct {
+		name                string
+		mockRequester       func(context.Context, *mocks.ClientHTTPRequester)
+		givenServiceAccount *ServiceAccount
+		wantServiceAccount  *ServiceAccount
+		wantErr             error
+	}{
+		{
+			name: "failed to create serviceAccount",
+			mockRequester: func(ctx context.Context, requester *mocks.ClientHTTPRequester) {
+				requester.EXPECT().
+					Request(ctx, http.MethodPost, fmt.Sprintf("%s/organizations/iam/service_accounts", defaultBaseURL), testServiceAccountInput, new(ServiceAccount)).
+					Return(http.StatusBadRequest, errors.New("failed to create service account"))
+			},
+			givenServiceAccount: testServiceAccountInput,
+			wantServiceAccount:  nil,
+			wantErr:             errors.New("failed after 1 attempt: failed to create service account"),
+		},
+		{
+			name: "happy path",
+			mockRequester: func(ctx context.Context, requester *mocks.ClientHTTPRequester) {
+				requester.EXPECT().
+					Request(ctx, http.MethodPost, fmt.Sprintf("%s/organizations/iam/service_accounts", defaultBaseURL), testServiceAccountInput, new(ServiceAccount)).
+					Return(http.StatusOK, nil).
+					Run(func(_ context.Context, _, _ string, _, output any) {
+						serviceAccount := output.(*ServiceAccount)
+						*serviceAccount = *testServiceAccountOutput
+					})
+			},
+			givenServiceAccount: testServiceAccountInput,
+			wantServiceAccount:  testServiceAccountOutput,
+			wantErr:             nil,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			requester := new(mocks.ClientHTTPRequester)
+			test.mockRequester(ctx, requester)
+
+			api := New(
+				WithRetryMax(0),
+			)
+			api.http = requester
+
+			gotServiceAccount, gotErr := api.CreateServiceAccount(ctx, test.givenServiceAccount)
+
+			if test.wantErr == nil {
+				assert.NoError(t, gotErr)
+			} else {
+				assert.EqualError(t, gotErr, test.wantErr.Error())
+			}
+			assert.Equal(t, test.wantServiceAccount, gotServiceAccount)
+		})
+	}
+}
+
+func Test_APIClient_UpdateServiceAccount(t *testing.T) {
+	t.Parallel()
+
+	testServiceAccount := &ServiceAccount{
+		Name:        "test-name",
+		Description: "Test description",
+		Role:        "admin",
+		ID:          "test-id",
+	}
+
+	tests := []struct {
+		name                string
+		mockRequester       func(context.Context, *mocks.ClientHTTPRequester)
+		givenServiceAccount *ServiceAccount
+		wantServiceAccount  *ServiceAccount
+		wantErr             error
+	}{
+		{
+			name: "failed to update service account",
+			mockRequester: func(ctx context.Context, requester *mocks.ClientHTTPRequester) {
+				requester.EXPECT().
+					Request(ctx, http.MethodPut, fmt.Sprintf("%s/organizations/iam/service_accounts/%s", defaultBaseURL, testServiceAccount.Name), testServiceAccount, new(ServiceAccount)).
+					Return(http.StatusBadRequest, errors.New("failed to update service account"))
+			},
+			givenServiceAccount: testServiceAccount,
+			wantServiceAccount:  nil,
+			wantErr:             errors.New("failed after 1 attempt: failed to update service account"),
+		},
+		{
+			name: "happy path",
+			mockRequester: func(ctx context.Context, requester *mocks.ClientHTTPRequester) {
+				requester.EXPECT().
+					Request(ctx, http.MethodPut, fmt.Sprintf("%s/organizations/iam/service_accounts/%s", defaultBaseURL, testServiceAccount.Name), testServiceAccount, new(ServiceAccount)).
+					Return(http.StatusOK, nil).
+					Run(func(_ context.Context, _, _ string, _, output any) {
+						serviceAccount := output.(*ServiceAccount)
+						*serviceAccount = *testServiceAccount
+					})
+			},
+			givenServiceAccount: testServiceAccount,
+			wantServiceAccount:  testServiceAccount,
+			wantErr:             nil,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			requester := new(mocks.ClientHTTPRequester)
+			test.mockRequester(ctx, requester)
+
+			api := New(
+				WithRetryMax(0),
+			)
+			api.http = requester
+
+			gotServiceAccount, gotErr := api.UpdateServiceAccount(ctx, test.givenServiceAccount)
+
+			if test.wantErr == nil {
+				assert.NoError(t, gotErr)
+			} else {
+				assert.EqualError(t, gotErr, test.wantErr.Error())
+			}
+			assert.Equal(t, test.wantServiceAccount, gotServiceAccount)
+		})
+	}
+}
+
+func Test_APIClient_DeleteServiceAccount(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		mockRequester func(context.Context, *mocks.ClientHTTPRequester)
+		givenName     string
+		wantErr       error
+	}{
+		{
+			name: "failed to delete service account",
+			mockRequester: func(ctx context.Context, requester *mocks.ClientHTTPRequester) {
+				requester.EXPECT().
+					Request(ctx, http.MethodDelete, fmt.Sprintf("%s/organizations/iam/service_accounts/%s", defaultBaseURL, "test-name"), nil, nil).
+					Return(http.StatusBadRequest, errors.New("failed to delete service account"))
+			},
+			givenName: "test-name",
+			wantErr:   errors.New("failed after 1 attempt: failed to delete service account"),
+		},
+		{
+			name: "404 not found error returned, but we will ignore it and return nil",
+			mockRequester: func(ctx context.Context, requester *mocks.ClientHTTPRequester) {
+				requester.EXPECT().
+					Request(ctx, http.MethodDelete, fmt.Sprintf("%s/organizations/iam/service_accounts/%s", defaultBaseURL, "test-name"), nil, nil).
+					Return(http.StatusNotFound, Error{Code: http.StatusNotFound, Message: "service account not found"})
+			},
+			givenName: "test-name",
+			wantErr:   nil,
+		},
+		{
+			name: "happy path",
+			mockRequester: func(ctx context.Context, requester *mocks.ClientHTTPRequester) {
+				requester.EXPECT().
+					Request(ctx, http.MethodDelete, fmt.Sprintf("%s/organizations/iam/service_accounts/%s", defaultBaseURL, "test-name"), nil, nil).
+					Return(http.StatusOK, nil)
+			},
+			givenName: "test-name",
+			wantErr:   nil,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			requester := new(mocks.ClientHTTPRequester)
+			test.mockRequester(ctx, requester)
+
+			api := New(
+				WithRetryMax(0),
+			)
+			api.http = requester
+
+			gotErr := api.DeleteServiceAccount(ctx, test.givenName)
+
+			if test.wantErr == nil {
+				assert.NoError(t, gotErr)
+			} else {
+				assert.EqualError(t, gotErr, test.wantErr.Error())
+			}
+		})
+	}
+}
+
+func Test_APIClient_CreateServiceAccountToken(t *testing.T) {
+	t.Parallel()
+
+	expiresAt, err := FlexibleTimeFrom("2030-01-01T00:00:00Z")
+	require.NoError(t, err)
+
+	createdAt, err := FlexibleTimeFrom("2020-01-01T00:00:00Z")
+	require.NoError(t, err)
+
+	testServiceAccountName := "test-name"
+
+	testServiceAccountTokenInput := &ServiceAccountToken{
+		Name:      "test-name",
+		ExpiresAt: expiresAt,
+	}
+	testServiceAccountTokenOutput := &ServiceAccountToken{
+		Token:     "test-token",
+		ID:        "test-id",
+		Name:      "test-name",
+		ExpiresAt: expiresAt,
+		CreatedAt: createdAt,
+	}
+
+	tests := []struct {
+		name                     string
+		mockRequester            func(context.Context, *mocks.ClientHTTPRequester)
+		givenServiceAccountToken *ServiceAccountToken
+		wantServiceAccountToken  *ServiceAccountToken
+		wantErr                  error
+	}{
+		{
+			name: "failed to create service account token",
+			mockRequester: func(ctx context.Context, requester *mocks.ClientHTTPRequester) {
+				requester.EXPECT().
+					Request(ctx, http.MethodPost, fmt.Sprintf("%s/organizations/iam/service_accounts/%s/tokens", defaultBaseURL, testServiceAccountName), testServiceAccountTokenInput, new(ServiceAccountToken)).
+					Return(http.StatusBadRequest, errors.New("failed to create service account token"))
+			},
+			givenServiceAccountToken: testServiceAccountTokenInput,
+			wantServiceAccountToken:  nil,
+			wantErr:                  errors.New("failed after 1 attempt: failed to create service account token"),
+		},
+		{
+			name: "happy path",
+			mockRequester: func(ctx context.Context, requester *mocks.ClientHTTPRequester) {
+				requester.EXPECT().
+					Request(ctx, http.MethodPost, fmt.Sprintf("%s/organizations/iam/service_accounts/%s/tokens", defaultBaseURL, testServiceAccountName), testServiceAccountTokenInput, new(ServiceAccountToken)).
+					Return(http.StatusOK, nil).
+					Run(func(_ context.Context, _, _ string, _, output any) {
+						serviceAccountToken := output.(*ServiceAccountToken)
+						*serviceAccountToken = *testServiceAccountTokenOutput
+					})
+			},
+			givenServiceAccountToken: testServiceAccountTokenInput,
+			wantServiceAccountToken:  testServiceAccountTokenOutput,
+			wantErr:                  nil,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			requester := new(mocks.ClientHTTPRequester)
+			test.mockRequester(ctx, requester)
+
+			api := New(
+				WithRetryMax(0),
+			)
+			api.http = requester
+
+			gotServiceAccountToken, gotErr := api.CreateServiceAccountToken(ctx, testServiceAccountName, test.givenServiceAccountToken)
+
+			if test.wantErr == nil {
+				assert.NoError(t, gotErr)
+			} else {
+				assert.EqualError(t, gotErr, test.wantErr.Error())
+			}
+			assert.Equal(t, test.wantServiceAccountToken, gotServiceAccountToken)
+		})
+	}
+}
+
+func Test_APIClient_DeleteServiceAccountToken(t *testing.T) {
+	t.Parallel()
+
+	testServiceAccountName := "test-service-account-name"
+
+	tests := []struct {
+		name                    string
+		mockRequester           func(context.Context, *mocks.ClientHTTPRequester)
+		givenServiceAccountName string
+		givenTokenID            string
+		wantErr                 error
+	}{
+		{
+			name: "failed to delete connector token",
+			mockRequester: func(ctx context.Context, requester *mocks.ClientHTTPRequester) {
+				requester.EXPECT().
+					Request(ctx, http.MethodDelete, fmt.Sprintf("%s/organizations/iam/service_accounts/%s/tokens/%s", defaultBaseURL, testServiceAccountName, "test-token-id"), nil, nil).
+					Return(http.StatusBadRequest, errors.New("failed to delete service account token"))
+			},
+			givenServiceAccountName: testServiceAccountName,
+			givenTokenID:            "test-token-id",
+			wantErr:                 errors.New("failed after 1 attempt: failed to delete service account token"),
+		},
+		{
+			name: "404 not found error returned, but we will ignore it and return nil",
+			mockRequester: func(ctx context.Context, requester *mocks.ClientHTTPRequester) {
+				requester.EXPECT().
+					Request(ctx, http.MethodDelete, fmt.Sprintf("%s/organizations/iam/service_accounts/%s/tokens/%s", defaultBaseURL, testServiceAccountName, "test-token-id"), nil, nil).
+					Return(http.StatusNotFound, Error{Code: http.StatusNotFound, Message: "service account token not found"})
+			},
+			givenServiceAccountName: testServiceAccountName,
+			givenTokenID:            "test-token-id",
+			wantErr:                 nil,
+		},
+		{
+			name: "happy path",
+			mockRequester: func(ctx context.Context, requester *mocks.ClientHTTPRequester) {
+				requester.EXPECT().
+					Request(ctx, http.MethodDelete, fmt.Sprintf("%s/organizations/iam/service_accounts/%s/tokens/%s", defaultBaseURL, testServiceAccountName, "test-token-id"), nil, nil).
+					Return(http.StatusOK, nil)
+			},
+			givenServiceAccountName: testServiceAccountName,
+			givenTokenID:            "test-token-id",
+			wantErr:                 nil,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			requester := new(mocks.ClientHTTPRequester)
+			test.mockRequester(ctx, requester)
+
+			api := New(
+				WithRetryMax(0),
+			)
+			api.http = requester
+
+			gotErr := api.DeleteServiceAccountToken(ctx, test.givenServiceAccountName, test.givenTokenID)
+
+			if test.wantErr == nil {
+				assert.NoError(t, gotErr)
+			} else {
+				assert.EqualError(t, gotErr, test.wantErr.Error())
+			}
+		})
+	}
+}

--- a/client/user.go
+++ b/client/user.go
@@ -1,0 +1,107 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// UserService is an interface for API client methods that interact with Border0 API to manage users.
+type UserService interface {
+	User(ctx context.Context, id string) (out *User, err error)
+	CreateUser(ctx context.Context, in *User, opts ...UserOption) (out *User, err error)
+	UpdateUser(ctx context.Context, in *User) (out *User, err error)
+	DeleteUser(ctx context.Context, id string) (err error)
+}
+
+type userConfig struct {
+	SkipNotification bool
+}
+
+// UserOption is a user creation option.
+type UserOption func(*userConfig)
+
+// WithSkipNotification is the UserOption to skip sending emails to notify added users of their addition.
+func WithSkipNotification(skip bool) UserOption {
+	return func(uc *userConfig) { uc.SkipNotification = skip }
+}
+
+// User fetches a user from your Border0 organization by UUID. User UUID is globally unique and immutable.
+func (api *APIClient) User(ctx context.Context, id string) (out *User, err error) {
+	out = new(User)
+	_, err = api.request(ctx, http.MethodGet, fmt.Sprintf("/organizations/iam/users/%s", id), nil, out)
+	if err != nil {
+		if NotFound(err) {
+			return nil, fmt.Errorf("user with ID [%s] not found: %w", id, err)
+		}
+		return nil, err
+	}
+	return out, nil
+}
+
+// CreateUser creates a new user in your Border0 organization. User email must
+// be unique within your organization, otherwise API will return an error.
+func (api *APIClient) CreateUser(ctx context.Context, in *User, opts ...UserOption) (out *User, err error) {
+	userConfig := &userConfig{}
+	for _, opt := range opts {
+		opt(userConfig)
+	}
+	url := "/organizations/iam/users"
+	if userConfig.SkipNotification {
+		url = fmt.Sprintf("%s?skip_notification=true", url)
+	}
+	out = new(User)
+	_, err = api.request(ctx, http.MethodPost, url, in, out)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// UpdateUser updates an existing user in your Border0 organization.
+func (api *APIClient) UpdateUser(ctx context.Context, in *User) (out *User, err error) {
+	out = new(User)
+	_, err = api.request(ctx, http.MethodPut, "/organizations/iam/users", in, out)
+	if err != nil {
+		if NotFound(err) {
+			return nil, fmt.Errorf("user with ID [%s] not found: %w", in.ID, err)
+		}
+		return nil, err
+	}
+	return out, nil
+}
+
+// DeleteUser deletes an existing user from your Border0 organization.
+func (api *APIClient) DeleteUser(ctx context.Context, id string) (err error) {
+	_, err = api.request(ctx, http.MethodDelete, fmt.Sprintf("/organizations/iam/users/%s", id), nil, nil)
+	if err != nil {
+		if NotFound(err) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+// User represents a user in your Border0 organization.
+type User struct {
+	// input and output fields
+	Email       string `json:"email"`
+	DisplayName string `json:"display_name"`
+	Role        string `json:"role"`
+
+	// output field
+	ID               string            `json:"id"`
+	UserType         string            `json:"user_type"`
+	DirectoryService *DirectoryService `json:"directory_service,omitempty"`
+}
+
+// DirectoryService represents a directory service in your Border0 organization.
+type DirectoryService struct {
+	// input fields
+	DisplayName string `json:"display_name"`
+	ServiceType string `json:"service_type"`
+
+	// output fields
+	ID string `json:"id"`
+}

--- a/client/user_test.go
+++ b/client/user_test.go
@@ -1,0 +1,310 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/borderzero/border0-go/client/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func Test_APIClient_User(t *testing.T) {
+	t.Parallel()
+
+	testUser := &User{
+		Email:       "test-name",
+		DisplayName: "Test description",
+		Role:        "admin",
+		ID:          "test-id",
+	}
+
+	tests := []struct {
+		name          string
+		mockRequester func(context.Context, *mocks.ClientHTTPRequester)
+		givenID       string
+		wantUser      *User
+		wantErr       error
+	}{
+		{
+			name: "failed to get user",
+			mockRequester: func(ctx context.Context, requester *mocks.ClientHTTPRequester) {
+				requester.EXPECT().
+					Request(ctx, http.MethodGet, fmt.Sprintf("%s/organizations/iam/users/%s", defaultBaseURL, "test-id"), nil, new(User)).
+					Return(http.StatusBadRequest, errors.New("failed to get user"))
+			},
+			givenID:  "test-id",
+			wantUser: nil,
+			wantErr:  errors.New("failed after 1 attempt: failed to get user"),
+		},
+		{
+			name: "404 not found error returned, let's make sure we wrap the error with more info",
+			mockRequester: func(ctx context.Context, requester *mocks.ClientHTTPRequester) {
+				requester.EXPECT().
+					Request(ctx, http.MethodGet, fmt.Sprintf("%s/organizations/iam/users/%s", defaultBaseURL, "test-id"), nil, new(User)).
+					Return(http.StatusNotFound, Error{Code: http.StatusNotFound, Message: "user not found"})
+			},
+			givenID: "test-id",
+			wantErr: errors.New("user with ID [test-id] not found: failed after 4 attempts: 404: user not found"),
+		},
+		{
+			name: "happy path",
+			mockRequester: func(ctx context.Context, requester *mocks.ClientHTTPRequester) {
+				// have to use On() instead of EXPECT() because we need to set the output
+				// and the Run() function would raise nil pointer panic if we use it with
+				// EXPECT()
+				requester.On("Request", ctx, http.MethodGet, fmt.Sprintf("%s/organizations/iam/users/%s", defaultBaseURL, "test-id"), nil, new(User)).
+					Return(http.StatusOK, nil).
+					Run(func(args mock.Arguments) {
+						output := args.Get(4).(*User)
+						*output = *testUser
+					})
+			},
+			givenID:  "test-id",
+			wantUser: testUser,
+			wantErr:  nil,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			requester := new(mocks.ClientHTTPRequester)
+			test.mockRequester(ctx, requester)
+
+			api := New(
+				WithRetryMax(0),
+			)
+			api.http = requester
+
+			gotUser, gotErr := api.User(ctx, test.givenID)
+
+			if test.wantErr == nil {
+				assert.NoError(t, gotErr)
+			} else {
+				assert.EqualError(t, gotErr, test.wantErr.Error())
+			}
+			assert.Equal(t, test.wantUser, gotUser)
+		})
+	}
+}
+
+func Test_APIClient_CreateUser(t *testing.T) {
+	t.Parallel()
+
+	testUserInput := &User{
+		Email:       "testemail@gmail.com",
+		DisplayName: "Test description",
+		Role:        "admin",
+	}
+
+	testUserOutput := &User{
+		Email:       "testemail@gmail.com",
+		DisplayName: "Test description",
+		Role:        "admin",
+		ID:          "test-id",
+	}
+
+	tests := []struct {
+		name          string
+		mockRequester func(context.Context, *mocks.ClientHTTPRequester)
+		givenUser     *User
+		wantUser      *User
+		wantErr       error
+	}{
+		{
+			name: "failed to create user",
+			mockRequester: func(ctx context.Context, requester *mocks.ClientHTTPRequester) {
+				requester.EXPECT().
+					Request(ctx, http.MethodPost, fmt.Sprintf("%s/organizations/iam/users", defaultBaseURL), testUserInput, new(User)).
+					Return(http.StatusBadRequest, errors.New("failed to create user"))
+			},
+			givenUser: testUserInput,
+			wantUser:  nil,
+			wantErr:   errors.New("failed after 1 attempt: failed to create user"),
+		},
+		{
+			name: "happy path",
+			mockRequester: func(ctx context.Context, requester *mocks.ClientHTTPRequester) {
+				requester.EXPECT().
+					Request(ctx, http.MethodPost, fmt.Sprintf("%s/organizations/iam/users", defaultBaseURL), testUserInput, new(User)).
+					Return(http.StatusOK, nil).
+					Run(func(_ context.Context, _, _ string, _, output any) {
+						user := output.(*User)
+						*user = *testUserOutput
+					})
+			},
+			givenUser: testUserInput,
+			wantUser:  testUserOutput,
+			wantErr:   nil,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			requester := new(mocks.ClientHTTPRequester)
+			test.mockRequester(ctx, requester)
+
+			api := New(
+				WithRetryMax(0),
+			)
+			api.http = requester
+
+			gotUser, gotErr := api.CreateUser(ctx, test.givenUser)
+
+			if test.wantErr == nil {
+				assert.NoError(t, gotErr)
+			} else {
+				assert.EqualError(t, gotErr, test.wantErr.Error())
+			}
+			assert.Equal(t, test.wantUser, gotUser)
+		})
+	}
+}
+
+func Test_APIClient_UpdateUser(t *testing.T) {
+	t.Parallel()
+
+	testUser := &User{
+		Email:       "testemail@gmail.com",
+		DisplayName: "Test description",
+		Role:        "admin",
+		ID:          "test-id",
+	}
+
+	tests := []struct {
+		name          string
+		mockRequester func(context.Context, *mocks.ClientHTTPRequester)
+		givenUser     *User
+		wantUser      *User
+		wantErr       error
+	}{
+		{
+			name: "failed to update user",
+			mockRequester: func(ctx context.Context, requester *mocks.ClientHTTPRequester) {
+				requester.EXPECT().
+					Request(ctx, http.MethodPut, fmt.Sprintf("%s/organizations/iam/users", defaultBaseURL), testUser, new(User)).
+					Return(http.StatusBadRequest, errors.New("failed to update user"))
+			},
+			givenUser: testUser,
+			wantUser:  nil,
+			wantErr:   errors.New("failed after 1 attempt: failed to update user"),
+		},
+		{
+			name: "happy path",
+			mockRequester: func(ctx context.Context, requester *mocks.ClientHTTPRequester) {
+				requester.EXPECT().
+					Request(ctx, http.MethodPut, fmt.Sprintf("%s/organizations/iam/users", defaultBaseURL), testUser, new(User)).
+					Return(http.StatusOK, nil).
+					Run(func(_ context.Context, _, _ string, _, output any) {
+						user := output.(*User)
+						*user = *testUser
+					})
+			},
+			givenUser: testUser,
+			wantUser:  testUser,
+			wantErr:   nil,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			requester := new(mocks.ClientHTTPRequester)
+			test.mockRequester(ctx, requester)
+
+			api := New(
+				WithRetryMax(0),
+			)
+			api.http = requester
+
+			gotUser, gotErr := api.UpdateUser(ctx, test.givenUser)
+
+			if test.wantErr == nil {
+				assert.NoError(t, gotErr)
+			} else {
+				assert.EqualError(t, gotErr, test.wantErr.Error())
+			}
+			assert.Equal(t, test.wantUser, gotUser)
+		})
+	}
+}
+
+func Test_APIClient_DeleteUser(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		mockRequester func(context.Context, *mocks.ClientHTTPRequester)
+		givenID       string
+		wantErr       error
+	}{
+		{
+			name: "failed to delete user",
+			mockRequester: func(ctx context.Context, requester *mocks.ClientHTTPRequester) {
+				requester.EXPECT().
+					Request(ctx, http.MethodDelete, fmt.Sprintf("%s/organizations/iam/users/%s", defaultBaseURL, "test-id"), nil, nil).
+					Return(http.StatusBadRequest, errors.New("failed to delete user"))
+			},
+			givenID: "test-id",
+			wantErr: errors.New("failed after 1 attempt: failed to delete user"),
+		},
+		{
+			name: "404 not found error returned, but we will ignore it and return nil",
+			mockRequester: func(ctx context.Context, requester *mocks.ClientHTTPRequester) {
+				requester.EXPECT().
+					Request(ctx, http.MethodDelete, fmt.Sprintf("%s/organizations/iam/users/%s", defaultBaseURL, "test-id"), nil, nil).
+					Return(http.StatusNotFound, Error{Code: http.StatusNotFound, Message: "user not found"})
+			},
+			givenID: "test-id",
+			wantErr: nil,
+		},
+		{
+			name: "happy path",
+			mockRequester: func(ctx context.Context, requester *mocks.ClientHTTPRequester) {
+				requester.EXPECT().
+					Request(ctx, http.MethodDelete, fmt.Sprintf("%s/organizations/iam/users/%s", defaultBaseURL, "test-id"), nil, nil).
+					Return(http.StatusOK, nil)
+			},
+			givenID: "test-id",
+			wantErr: nil,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			requester := new(mocks.ClientHTTPRequester)
+			test.mockRequester(ctx, requester)
+
+			api := New(
+				WithRetryMax(0),
+			)
+			api.http = requester
+
+			gotErr := api.DeleteUser(ctx, test.givenID)
+
+			if test.wantErr == nil {
+				assert.NoError(t, gotErr)
+			} else {
+				assert.EqualError(t, gotErr, test.wantErr.Error())
+			}
+		})
+	}
+}

--- a/listen/mocks/api_client_requester.go
+++ b/listen/mocks/api_client_requester.go
@@ -537,6 +537,65 @@ func (_c *APIClientRequester_CreateConnectorToken_Call) RunAndReturn(run func(co
 	return _c
 }
 
+// CreateGroup provides a mock function with given fields: ctx, in
+func (_m *APIClientRequester) CreateGroup(ctx context.Context, in *client.Group) (*client.Group, error) {
+	ret := _m.Called(ctx, in)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateGroup")
+	}
+
+	var r0 *client.Group
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *client.Group) (*client.Group, error)); ok {
+		return rf(ctx, in)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *client.Group) *client.Group); ok {
+		r0 = rf(ctx, in)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*client.Group)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *client.Group) error); ok {
+		r1 = rf(ctx, in)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// APIClientRequester_CreateGroup_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateGroup'
+type APIClientRequester_CreateGroup_Call struct {
+	*mock.Call
+}
+
+// CreateGroup is a helper method to define mock.On call
+//   - ctx context.Context
+//   - in *client.Group
+func (_e *APIClientRequester_Expecter) CreateGroup(ctx interface{}, in interface{}) *APIClientRequester_CreateGroup_Call {
+	return &APIClientRequester_CreateGroup_Call{Call: _e.mock.On("CreateGroup", ctx, in)}
+}
+
+func (_c *APIClientRequester_CreateGroup_Call) Run(run func(ctx context.Context, in *client.Group)) *APIClientRequester_CreateGroup_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*client.Group))
+	})
+	return _c
+}
+
+func (_c *APIClientRequester_CreateGroup_Call) Return(out *client.Group, err error) *APIClientRequester_CreateGroup_Call {
+	_c.Call.Return(out, err)
+	return _c
+}
+
+func (_c *APIClientRequester_CreateGroup_Call) RunAndReturn(run func(context.Context, *client.Group) (*client.Group, error)) *APIClientRequester_CreateGroup_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CreatePolicy provides a mock function with given fields: ctx, in
 func (_m *APIClientRequester) CreatePolicy(ctx context.Context, in *client.Policy) (*client.Policy, error) {
 	ret := _m.Called(ctx, in)
@@ -596,6 +655,125 @@ func (_c *APIClientRequester_CreatePolicy_Call) RunAndReturn(run func(context.Co
 	return _c
 }
 
+// CreateServiceAccount provides a mock function with given fields: ctx, in
+func (_m *APIClientRequester) CreateServiceAccount(ctx context.Context, in *client.ServiceAccount) (*client.ServiceAccount, error) {
+	ret := _m.Called(ctx, in)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateServiceAccount")
+	}
+
+	var r0 *client.ServiceAccount
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *client.ServiceAccount) (*client.ServiceAccount, error)); ok {
+		return rf(ctx, in)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *client.ServiceAccount) *client.ServiceAccount); ok {
+		r0 = rf(ctx, in)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*client.ServiceAccount)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *client.ServiceAccount) error); ok {
+		r1 = rf(ctx, in)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// APIClientRequester_CreateServiceAccount_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateServiceAccount'
+type APIClientRequester_CreateServiceAccount_Call struct {
+	*mock.Call
+}
+
+// CreateServiceAccount is a helper method to define mock.On call
+//   - ctx context.Context
+//   - in *client.ServiceAccount
+func (_e *APIClientRequester_Expecter) CreateServiceAccount(ctx interface{}, in interface{}) *APIClientRequester_CreateServiceAccount_Call {
+	return &APIClientRequester_CreateServiceAccount_Call{Call: _e.mock.On("CreateServiceAccount", ctx, in)}
+}
+
+func (_c *APIClientRequester_CreateServiceAccount_Call) Run(run func(ctx context.Context, in *client.ServiceAccount)) *APIClientRequester_CreateServiceAccount_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*client.ServiceAccount))
+	})
+	return _c
+}
+
+func (_c *APIClientRequester_CreateServiceAccount_Call) Return(out *client.ServiceAccount, err error) *APIClientRequester_CreateServiceAccount_Call {
+	_c.Call.Return(out, err)
+	return _c
+}
+
+func (_c *APIClientRequester_CreateServiceAccount_Call) RunAndReturn(run func(context.Context, *client.ServiceAccount) (*client.ServiceAccount, error)) *APIClientRequester_CreateServiceAccount_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CreateServiceAccountToken provides a mock function with given fields: ctx, serviceAccountName, in
+func (_m *APIClientRequester) CreateServiceAccountToken(ctx context.Context, serviceAccountName string, in *client.ServiceAccountToken) (*client.ServiceAccountToken, error) {
+	ret := _m.Called(ctx, serviceAccountName, in)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateServiceAccountToken")
+	}
+
+	var r0 *client.ServiceAccountToken
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, *client.ServiceAccountToken) (*client.ServiceAccountToken, error)); ok {
+		return rf(ctx, serviceAccountName, in)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, *client.ServiceAccountToken) *client.ServiceAccountToken); ok {
+		r0 = rf(ctx, serviceAccountName, in)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*client.ServiceAccountToken)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, *client.ServiceAccountToken) error); ok {
+		r1 = rf(ctx, serviceAccountName, in)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// APIClientRequester_CreateServiceAccountToken_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateServiceAccountToken'
+type APIClientRequester_CreateServiceAccountToken_Call struct {
+	*mock.Call
+}
+
+// CreateServiceAccountToken is a helper method to define mock.On call
+//   - ctx context.Context
+//   - serviceAccountName string
+//   - in *client.ServiceAccountToken
+func (_e *APIClientRequester_Expecter) CreateServiceAccountToken(ctx interface{}, serviceAccountName interface{}, in interface{}) *APIClientRequester_CreateServiceAccountToken_Call {
+	return &APIClientRequester_CreateServiceAccountToken_Call{Call: _e.mock.On("CreateServiceAccountToken", ctx, serviceAccountName, in)}
+}
+
+func (_c *APIClientRequester_CreateServiceAccountToken_Call) Run(run func(ctx context.Context, serviceAccountName string, in *client.ServiceAccountToken)) *APIClientRequester_CreateServiceAccountToken_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(*client.ServiceAccountToken))
+	})
+	return _c
+}
+
+func (_c *APIClientRequester_CreateServiceAccountToken_Call) Return(out *client.ServiceAccountToken, err error) *APIClientRequester_CreateServiceAccountToken_Call {
+	_c.Call.Return(out, err)
+	return _c
+}
+
+func (_c *APIClientRequester_CreateServiceAccountToken_Call) RunAndReturn(run func(context.Context, string, *client.ServiceAccountToken) (*client.ServiceAccountToken, error)) *APIClientRequester_CreateServiceAccountToken_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CreateSocket provides a mock function with given fields: ctx, in
 func (_m *APIClientRequester) CreateSocket(ctx context.Context, in *client.Socket) (*client.Socket, error) {
 	ret := _m.Called(ctx, in)
@@ -651,6 +829,80 @@ func (_c *APIClientRequester_CreateSocket_Call) Return(out *client.Socket, err e
 }
 
 func (_c *APIClientRequester_CreateSocket_Call) RunAndReturn(run func(context.Context, *client.Socket) (*client.Socket, error)) *APIClientRequester_CreateSocket_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CreateUser provides a mock function with given fields: ctx, in, opts
+func (_m *APIClientRequester) CreateUser(ctx context.Context, in *client.User, opts ...client.UserOption) (*client.User, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, in)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateUser")
+	}
+
+	var r0 *client.User
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *client.User, ...client.UserOption) (*client.User, error)); ok {
+		return rf(ctx, in, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *client.User, ...client.UserOption) *client.User); ok {
+		r0 = rf(ctx, in, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*client.User)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *client.User, ...client.UserOption) error); ok {
+		r1 = rf(ctx, in, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// APIClientRequester_CreateUser_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateUser'
+type APIClientRequester_CreateUser_Call struct {
+	*mock.Call
+}
+
+// CreateUser is a helper method to define mock.On call
+//   - ctx context.Context
+//   - in *client.User
+//   - opts ...client.UserOption
+func (_e *APIClientRequester_Expecter) CreateUser(ctx interface{}, in interface{}, opts ...interface{}) *APIClientRequester_CreateUser_Call {
+	return &APIClientRequester_CreateUser_Call{Call: _e.mock.On("CreateUser",
+		append([]interface{}{ctx, in}, opts...)...)}
+}
+
+func (_c *APIClientRequester_CreateUser_Call) Run(run func(ctx context.Context, in *client.User, opts ...client.UserOption)) *APIClientRequester_CreateUser_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]client.UserOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(client.UserOption)
+			}
+		}
+		run(args[0].(context.Context), args[1].(*client.User), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *APIClientRequester_CreateUser_Call) Return(out *client.User, err error) *APIClientRequester_CreateUser_Call {
+	_c.Call.Return(out, err)
+	return _c
+}
+
+func (_c *APIClientRequester_CreateUser_Call) RunAndReturn(run func(context.Context, *client.User, ...client.UserOption) (*client.User, error)) *APIClientRequester_CreateUser_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -750,6 +1002,53 @@ func (_c *APIClientRequester_DeleteConnectorToken_Call) RunAndReturn(run func(co
 	return _c
 }
 
+// DeleteGroup provides a mock function with given fields: ctx, id
+func (_m *APIClientRequester) DeleteGroup(ctx context.Context, id string) error {
+	ret := _m.Called(ctx, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteGroup")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, id)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// APIClientRequester_DeleteGroup_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteGroup'
+type APIClientRequester_DeleteGroup_Call struct {
+	*mock.Call
+}
+
+// DeleteGroup is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+func (_e *APIClientRequester_Expecter) DeleteGroup(ctx interface{}, id interface{}) *APIClientRequester_DeleteGroup_Call {
+	return &APIClientRequester_DeleteGroup_Call{Call: _e.mock.On("DeleteGroup", ctx, id)}
+}
+
+func (_c *APIClientRequester_DeleteGroup_Call) Run(run func(ctx context.Context, id string)) *APIClientRequester_DeleteGroup_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *APIClientRequester_DeleteGroup_Call) Return(err error) *APIClientRequester_DeleteGroup_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *APIClientRequester_DeleteGroup_Call) RunAndReturn(run func(context.Context, string) error) *APIClientRequester_DeleteGroup_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // DeletePolicy provides a mock function with given fields: ctx, id
 func (_m *APIClientRequester) DeletePolicy(ctx context.Context, id string) error {
 	ret := _m.Called(ctx, id)
@@ -797,6 +1096,101 @@ func (_c *APIClientRequester_DeletePolicy_Call) RunAndReturn(run func(context.Co
 	return _c
 }
 
+// DeleteServiceAccount provides a mock function with given fields: ctx, id
+func (_m *APIClientRequester) DeleteServiceAccount(ctx context.Context, id string) error {
+	ret := _m.Called(ctx, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteServiceAccount")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, id)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// APIClientRequester_DeleteServiceAccount_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteServiceAccount'
+type APIClientRequester_DeleteServiceAccount_Call struct {
+	*mock.Call
+}
+
+// DeleteServiceAccount is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+func (_e *APIClientRequester_Expecter) DeleteServiceAccount(ctx interface{}, id interface{}) *APIClientRequester_DeleteServiceAccount_Call {
+	return &APIClientRequester_DeleteServiceAccount_Call{Call: _e.mock.On("DeleteServiceAccount", ctx, id)}
+}
+
+func (_c *APIClientRequester_DeleteServiceAccount_Call) Run(run func(ctx context.Context, id string)) *APIClientRequester_DeleteServiceAccount_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *APIClientRequester_DeleteServiceAccount_Call) Return(err error) *APIClientRequester_DeleteServiceAccount_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *APIClientRequester_DeleteServiceAccount_Call) RunAndReturn(run func(context.Context, string) error) *APIClientRequester_DeleteServiceAccount_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// DeleteServiceAccountToken provides a mock function with given fields: ctx, serviceAccountName, tokenID
+func (_m *APIClientRequester) DeleteServiceAccountToken(ctx context.Context, serviceAccountName string, tokenID string) error {
+	ret := _m.Called(ctx, serviceAccountName, tokenID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteServiceAccountToken")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = rf(ctx, serviceAccountName, tokenID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// APIClientRequester_DeleteServiceAccountToken_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteServiceAccountToken'
+type APIClientRequester_DeleteServiceAccountToken_Call struct {
+	*mock.Call
+}
+
+// DeleteServiceAccountToken is a helper method to define mock.On call
+//   - ctx context.Context
+//   - serviceAccountName string
+//   - tokenID string
+func (_e *APIClientRequester_Expecter) DeleteServiceAccountToken(ctx interface{}, serviceAccountName interface{}, tokenID interface{}) *APIClientRequester_DeleteServiceAccountToken_Call {
+	return &APIClientRequester_DeleteServiceAccountToken_Call{Call: _e.mock.On("DeleteServiceAccountToken", ctx, serviceAccountName, tokenID)}
+}
+
+func (_c *APIClientRequester_DeleteServiceAccountToken_Call) Run(run func(ctx context.Context, serviceAccountName string, tokenID string)) *APIClientRequester_DeleteServiceAccountToken_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string))
+	})
+	return _c
+}
+
+func (_c *APIClientRequester_DeleteServiceAccountToken_Call) Return(err error) *APIClientRequester_DeleteServiceAccountToken_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *APIClientRequester_DeleteServiceAccountToken_Call) RunAndReturn(run func(context.Context, string, string) error) *APIClientRequester_DeleteServiceAccountToken_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // DeleteSocket provides a mock function with given fields: ctx, idOrName
 func (_m *APIClientRequester) DeleteSocket(ctx context.Context, idOrName string) error {
 	ret := _m.Called(ctx, idOrName)
@@ -840,6 +1234,112 @@ func (_c *APIClientRequester_DeleteSocket_Call) Return(err error) *APIClientRequ
 }
 
 func (_c *APIClientRequester_DeleteSocket_Call) RunAndReturn(run func(context.Context, string) error) *APIClientRequester_DeleteSocket_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// DeleteUser provides a mock function with given fields: ctx, id
+func (_m *APIClientRequester) DeleteUser(ctx context.Context, id string) error {
+	ret := _m.Called(ctx, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteUser")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, id)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// APIClientRequester_DeleteUser_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteUser'
+type APIClientRequester_DeleteUser_Call struct {
+	*mock.Call
+}
+
+// DeleteUser is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+func (_e *APIClientRequester_Expecter) DeleteUser(ctx interface{}, id interface{}) *APIClientRequester_DeleteUser_Call {
+	return &APIClientRequester_DeleteUser_Call{Call: _e.mock.On("DeleteUser", ctx, id)}
+}
+
+func (_c *APIClientRequester_DeleteUser_Call) Run(run func(ctx context.Context, id string)) *APIClientRequester_DeleteUser_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *APIClientRequester_DeleteUser_Call) Return(err error) *APIClientRequester_DeleteUser_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *APIClientRequester_DeleteUser_Call) RunAndReturn(run func(context.Context, string) error) *APIClientRequester_DeleteUser_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// Group provides a mock function with given fields: ctx, id
+func (_m *APIClientRequester) Group(ctx context.Context, id string) (*client.Group, error) {
+	ret := _m.Called(ctx, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Group")
+	}
+
+	var r0 *client.Group
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (*client.Group, error)); ok {
+		return rf(ctx, id)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) *client.Group); ok {
+		r0 = rf(ctx, id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*client.Group)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// APIClientRequester_Group_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Group'
+type APIClientRequester_Group_Call struct {
+	*mock.Call
+}
+
+// Group is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+func (_e *APIClientRequester_Expecter) Group(ctx interface{}, id interface{}) *APIClientRequester_Group_Call {
+	return &APIClientRequester_Group_Call{Call: _e.mock.On("Group", ctx, id)}
+}
+
+func (_c *APIClientRequester_Group_Call) Run(run func(ctx context.Context, id string)) *APIClientRequester_Group_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *APIClientRequester_Group_Call) Return(out *client.Group, err error) *APIClientRequester_Group_Call {
+	_c.Call.Return(out, err)
+	return _c
+}
+
+func (_c *APIClientRequester_Group_Call) RunAndReturn(run func(context.Context, string) (*client.Group, error)) *APIClientRequester_Group_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1126,6 +1626,125 @@ func (_c *APIClientRequester_RemovePolicyFromSocket_Call) Return(err error) *API
 }
 
 func (_c *APIClientRequester_RemovePolicyFromSocket_Call) RunAndReturn(run func(context.Context, string, string) error) *APIClientRequester_RemovePolicyFromSocket_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ServiceAccount provides a mock function with given fields: ctx, name
+func (_m *APIClientRequester) ServiceAccount(ctx context.Context, name string) (*client.ServiceAccount, error) {
+	ret := _m.Called(ctx, name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ServiceAccount")
+	}
+
+	var r0 *client.ServiceAccount
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (*client.ServiceAccount, error)); ok {
+		return rf(ctx, name)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) *client.ServiceAccount); ok {
+		r0 = rf(ctx, name)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*client.ServiceAccount)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, name)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// APIClientRequester_ServiceAccount_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ServiceAccount'
+type APIClientRequester_ServiceAccount_Call struct {
+	*mock.Call
+}
+
+// ServiceAccount is a helper method to define mock.On call
+//   - ctx context.Context
+//   - name string
+func (_e *APIClientRequester_Expecter) ServiceAccount(ctx interface{}, name interface{}) *APIClientRequester_ServiceAccount_Call {
+	return &APIClientRequester_ServiceAccount_Call{Call: _e.mock.On("ServiceAccount", ctx, name)}
+}
+
+func (_c *APIClientRequester_ServiceAccount_Call) Run(run func(ctx context.Context, name string)) *APIClientRequester_ServiceAccount_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *APIClientRequester_ServiceAccount_Call) Return(out *client.ServiceAccount, err error) *APIClientRequester_ServiceAccount_Call {
+	_c.Call.Return(out, err)
+	return _c
+}
+
+func (_c *APIClientRequester_ServiceAccount_Call) RunAndReturn(run func(context.Context, string) (*client.ServiceAccount, error)) *APIClientRequester_ServiceAccount_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ServiceAccountToken provides a mock function with given fields: ctx, serviceAccountName, tokenID
+func (_m *APIClientRequester) ServiceAccountToken(ctx context.Context, serviceAccountName string, tokenID string) (*client.ServiceAccountToken, error) {
+	ret := _m.Called(ctx, serviceAccountName, tokenID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ServiceAccountToken")
+	}
+
+	var r0 *client.ServiceAccountToken
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) (*client.ServiceAccountToken, error)); ok {
+		return rf(ctx, serviceAccountName, tokenID)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) *client.ServiceAccountToken); ok {
+		r0 = rf(ctx, serviceAccountName, tokenID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*client.ServiceAccountToken)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = rf(ctx, serviceAccountName, tokenID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// APIClientRequester_ServiceAccountToken_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ServiceAccountToken'
+type APIClientRequester_ServiceAccountToken_Call struct {
+	*mock.Call
+}
+
+// ServiceAccountToken is a helper method to define mock.On call
+//   - ctx context.Context
+//   - serviceAccountName string
+//   - tokenID string
+func (_e *APIClientRequester_Expecter) ServiceAccountToken(ctx interface{}, serviceAccountName interface{}, tokenID interface{}) *APIClientRequester_ServiceAccountToken_Call {
+	return &APIClientRequester_ServiceAccountToken_Call{Call: _e.mock.On("ServiceAccountToken", ctx, serviceAccountName, tokenID)}
+}
+
+func (_c *APIClientRequester_ServiceAccountToken_Call) Run(run func(ctx context.Context, serviceAccountName string, tokenID string)) *APIClientRequester_ServiceAccountToken_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string))
+	})
+	return _c
+}
+
+func (_c *APIClientRequester_ServiceAccountToken_Call) Return(out *client.ServiceAccountToken, err error) *APIClientRequester_ServiceAccountToken_Call {
+	_c.Call.Return(out, err)
+	return _c
+}
+
+func (_c *APIClientRequester_ServiceAccountToken_Call) RunAndReturn(run func(context.Context, string, string) (*client.ServiceAccountToken, error)) *APIClientRequester_ServiceAccountToken_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1541,6 +2160,65 @@ func (_c *APIClientRequester_UpdateConnector_Call) RunAndReturn(run func(context
 	return _c
 }
 
+// UpdateGroup provides a mock function with given fields: ctx, in
+func (_m *APIClientRequester) UpdateGroup(ctx context.Context, in *client.Group) (*client.Group, error) {
+	ret := _m.Called(ctx, in)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateGroup")
+	}
+
+	var r0 *client.Group
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *client.Group) (*client.Group, error)); ok {
+		return rf(ctx, in)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *client.Group) *client.Group); ok {
+		r0 = rf(ctx, in)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*client.Group)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *client.Group) error); ok {
+		r1 = rf(ctx, in)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// APIClientRequester_UpdateGroup_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateGroup'
+type APIClientRequester_UpdateGroup_Call struct {
+	*mock.Call
+}
+
+// UpdateGroup is a helper method to define mock.On call
+//   - ctx context.Context
+//   - in *client.Group
+func (_e *APIClientRequester_Expecter) UpdateGroup(ctx interface{}, in interface{}) *APIClientRequester_UpdateGroup_Call {
+	return &APIClientRequester_UpdateGroup_Call{Call: _e.mock.On("UpdateGroup", ctx, in)}
+}
+
+func (_c *APIClientRequester_UpdateGroup_Call) Run(run func(ctx context.Context, in *client.Group)) *APIClientRequester_UpdateGroup_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*client.Group))
+	})
+	return _c
+}
+
+func (_c *APIClientRequester_UpdateGroup_Call) Return(out *client.Group, err error) *APIClientRequester_UpdateGroup_Call {
+	_c.Call.Return(out, err)
+	return _c
+}
+
+func (_c *APIClientRequester_UpdateGroup_Call) RunAndReturn(run func(context.Context, *client.Group) (*client.Group, error)) *APIClientRequester_UpdateGroup_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdatePolicy provides a mock function with given fields: ctx, id, in
 func (_m *APIClientRequester) UpdatePolicy(ctx context.Context, id string, in *client.Policy) (*client.Policy, error) {
 	ret := _m.Called(ctx, id, in)
@@ -1601,6 +2279,65 @@ func (_c *APIClientRequester_UpdatePolicy_Call) RunAndReturn(run func(context.Co
 	return _c
 }
 
+// UpdateServiceAccount provides a mock function with given fields: ctx, in
+func (_m *APIClientRequester) UpdateServiceAccount(ctx context.Context, in *client.ServiceAccount) (*client.ServiceAccount, error) {
+	ret := _m.Called(ctx, in)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateServiceAccount")
+	}
+
+	var r0 *client.ServiceAccount
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *client.ServiceAccount) (*client.ServiceAccount, error)); ok {
+		return rf(ctx, in)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *client.ServiceAccount) *client.ServiceAccount); ok {
+		r0 = rf(ctx, in)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*client.ServiceAccount)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *client.ServiceAccount) error); ok {
+		r1 = rf(ctx, in)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// APIClientRequester_UpdateServiceAccount_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateServiceAccount'
+type APIClientRequester_UpdateServiceAccount_Call struct {
+	*mock.Call
+}
+
+// UpdateServiceAccount is a helper method to define mock.On call
+//   - ctx context.Context
+//   - in *client.ServiceAccount
+func (_e *APIClientRequester_Expecter) UpdateServiceAccount(ctx interface{}, in interface{}) *APIClientRequester_UpdateServiceAccount_Call {
+	return &APIClientRequester_UpdateServiceAccount_Call{Call: _e.mock.On("UpdateServiceAccount", ctx, in)}
+}
+
+func (_c *APIClientRequester_UpdateServiceAccount_Call) Run(run func(ctx context.Context, in *client.ServiceAccount)) *APIClientRequester_UpdateServiceAccount_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*client.ServiceAccount))
+	})
+	return _c
+}
+
+func (_c *APIClientRequester_UpdateServiceAccount_Call) Return(out *client.ServiceAccount, err error) *APIClientRequester_UpdateServiceAccount_Call {
+	_c.Call.Return(out, err)
+	return _c
+}
+
+func (_c *APIClientRequester_UpdateServiceAccount_Call) RunAndReturn(run func(context.Context, *client.ServiceAccount) (*client.ServiceAccount, error)) *APIClientRequester_UpdateServiceAccount_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdateSocket provides a mock function with given fields: ctx, idOrName, in
 func (_m *APIClientRequester) UpdateSocket(ctx context.Context, idOrName string, in *client.Socket) (*client.Socket, error) {
 	ret := _m.Called(ctx, idOrName, in)
@@ -1657,6 +2394,124 @@ func (_c *APIClientRequester_UpdateSocket_Call) Return(out *client.Socket, err e
 }
 
 func (_c *APIClientRequester_UpdateSocket_Call) RunAndReturn(run func(context.Context, string, *client.Socket) (*client.Socket, error)) *APIClientRequester_UpdateSocket_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpdateUser provides a mock function with given fields: ctx, in
+func (_m *APIClientRequester) UpdateUser(ctx context.Context, in *client.User) (*client.User, error) {
+	ret := _m.Called(ctx, in)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateUser")
+	}
+
+	var r0 *client.User
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *client.User) (*client.User, error)); ok {
+		return rf(ctx, in)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *client.User) *client.User); ok {
+		r0 = rf(ctx, in)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*client.User)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *client.User) error); ok {
+		r1 = rf(ctx, in)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// APIClientRequester_UpdateUser_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateUser'
+type APIClientRequester_UpdateUser_Call struct {
+	*mock.Call
+}
+
+// UpdateUser is a helper method to define mock.On call
+//   - ctx context.Context
+//   - in *client.User
+func (_e *APIClientRequester_Expecter) UpdateUser(ctx interface{}, in interface{}) *APIClientRequester_UpdateUser_Call {
+	return &APIClientRequester_UpdateUser_Call{Call: _e.mock.On("UpdateUser", ctx, in)}
+}
+
+func (_c *APIClientRequester_UpdateUser_Call) Run(run func(ctx context.Context, in *client.User)) *APIClientRequester_UpdateUser_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*client.User))
+	})
+	return _c
+}
+
+func (_c *APIClientRequester_UpdateUser_Call) Return(out *client.User, err error) *APIClientRequester_UpdateUser_Call {
+	_c.Call.Return(out, err)
+	return _c
+}
+
+func (_c *APIClientRequester_UpdateUser_Call) RunAndReturn(run func(context.Context, *client.User) (*client.User, error)) *APIClientRequester_UpdateUser_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// User provides a mock function with given fields: ctx, id
+func (_m *APIClientRequester) User(ctx context.Context, id string) (*client.User, error) {
+	ret := _m.Called(ctx, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for User")
+	}
+
+	var r0 *client.User
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (*client.User, error)); ok {
+		return rf(ctx, id)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) *client.User); ok {
+		r0 = rf(ctx, id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*client.User)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// APIClientRequester_User_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'User'
+type APIClientRequester_User_Call struct {
+	*mock.Call
+}
+
+// User is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+func (_e *APIClientRequester_Expecter) User(ctx interface{}, id interface{}) *APIClientRequester_User_Call {
+	return &APIClientRequester_User_Call{Call: _e.mock.On("User", ctx, id)}
+}
+
+func (_c *APIClientRequester_User_Call) Run(run func(ctx context.Context, id string)) *APIClientRequester_User_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *APIClientRequester_User_Call) Return(out *client.User, err error) *APIClientRequester_User_Call {
+	_c.Call.Return(out, err)
+	return _c
+}
+
+func (_c *APIClientRequester_User_Call) RunAndReturn(run func(context.Context, string) (*client.User, error)) *APIClientRequester_User_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
## [[ME-3028](https://mysocket.atlassian.net/browse/ME-3028)] Add IAM Users, IAM Groups, and Service Accounts

Adds operations for users, groups, and service accounts.

[ME-3028]: https://mysocket.atlassian.net/browse/ME-3028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced functionality for managing groups, users, and service accounts within the application.
  - Added capabilities for creating, updating, and deleting groups, users, and service accounts.
  - Implemented error handling for operations like fetching and updating groups.

- **Enhancements**
  - Expanded API client to include services for user management, group management, and service account management.
  - Improved mock functions for better testing of API operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->