### PR TITLE
[ME-3048] Enable Listing Users

### DIFF
--- a/client/user.go
+++ b/client/user.go
@@ -9,6 +9,7 @@ import (
 // UserService is an interface for API client methods that interact with Border0 API to manage users.
 type UserService interface {
 	User(ctx context.Context, id string) (out *User, err error)
+	Users(ctx context.Context) (out *Users, err error)
 	CreateUser(ctx context.Context, in *User, opts ...UserOption) (out *User, err error)
 	UpdateUser(ctx context.Context, in *User) (out *User, err error)
 	DeleteUser(ctx context.Context, id string) (err error)
@@ -34,6 +35,16 @@ func (api *APIClient) User(ctx context.Context, id string) (out *User, err error
 		if NotFound(err) {
 			return nil, fmt.Errorf("user with ID [%s] not found: %w", id, err)
 		}
+		return nil, err
+	}
+	return out, nil
+}
+
+// Users fetches all users from your Border0 organization.
+func (api *APIClient) Users(ctx context.Context) (out *Users, err error) {
+	out = new(Users)
+	_, err = api.request(ctx, http.MethodGet, "/organizations/iam/users", nil, out)
+	if err != nil {
 		return nil, err
 	}
 	return out, nil
@@ -94,6 +105,11 @@ type User struct {
 	ID               string            `json:"id"`
 	UserType         string            `json:"user_type"`
 	DirectoryService *DirectoryService `json:"directory_service,omitempty"`
+}
+
+// Users represents a list of users in your Border0 organization.
+type Users struct {
+	List []User `json:"list"`
 }
 
 // DirectoryService represents a directory service in your Border0 organization.

--- a/listen/mocks/api_client_requester.go
+++ b/listen/mocks/api_client_requester.go
@@ -2516,6 +2516,64 @@ func (_c *APIClientRequester_User_Call) RunAndReturn(run func(context.Context, s
 	return _c
 }
 
+// Users provides a mock function with given fields: ctx
+func (_m *APIClientRequester) Users(ctx context.Context) (*client.Users, error) {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Users")
+	}
+
+	var r0 *client.Users
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context) (*client.Users, error)); ok {
+		return rf(ctx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context) *client.Users); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*client.Users)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// APIClientRequester_Users_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Users'
+type APIClientRequester_Users_Call struct {
+	*mock.Call
+}
+
+// Users is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *APIClientRequester_Expecter) Users(ctx interface{}) *APIClientRequester_Users_Call {
+	return &APIClientRequester_Users_Call{Call: _e.mock.On("Users", ctx)}
+}
+
+func (_c *APIClientRequester_Users_Call) Run(run func(ctx context.Context)) *APIClientRequester_Users_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context))
+	})
+	return _c
+}
+
+func (_c *APIClientRequester_Users_Call) Return(out *client.Users, err error) *APIClientRequester_Users_Call {
+	_c.Call.Return(out, err)
+	return _c
+}
+
+func (_c *APIClientRequester_Users_Call) RunAndReturn(run func(context.Context) (*client.Users, error)) *APIClientRequester_Users_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewAPIClientRequester creates a new instance of APIClientRequester. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewAPIClientRequester(t interface {


### PR DESCRIPTION
## [[ME-3048](https://mysocket.atlassian.net/browse/ME-3048)] Enable Listing Users

[ME-3048]: https://mysocket.atlassian.net/browse/ME-3048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new method to fetch all users within the Border0 organization.
  - Added support for mocking user-fetching functionality for testing purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->