### PR TITLE
[ME-3144] Allow omitempty for Kubernetes Policy Rules

### DIFF
--- a/client/policy.go
+++ b/client/policy.go
@@ -346,7 +346,7 @@ type VPNPermissions struct{}
 
 // KubernetesPermissions represents kubernetes service permissions for policy (v2).
 type KubernetesPermissions struct {
-	Rules []KubernetesRule `json:"rules"`
+	Rules *[]KubernetesRule `json:"rules,omitempty"`
 }
 
 // KubernetesRule represents a single kubernetes rule for kubernetes service permissions for policy (v2).


### PR DESCRIPTION
## [[ME-3144](https://mysocket.atlassian.net/browse/ME-3144)] Allow omitempty for Kubernetes Policy Rules

[ME-3144]: https://mysocket.atlassian.net/browse/ME-3144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved API response by omitting empty `Rules` fields in JSON output for Kubernetes permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->