### PR TITLE
[ME-3155] Match Policy Repo Model

### DIFF
--- a/client/policy.go
+++ b/client/policy.go
@@ -309,8 +309,8 @@ type SSHTCPForwardingPermission struct {
 
 // SSHTcpForwardingConnection represents data regarding a tcp forwarding ssh permission for policy (v2).
 type SSHTcpForwardingConnection struct {
-	DestinationAddress string `json:"destination_address,omitempty"`
-	DestinationPort    string `json:"destination_port,omitempty"`
+	DestinationAddress *string `json:"destination_address,omitempty"`
+	DestinationPort    *string `json:"destination_port,omitempty"`
 }
 
 // SSHKubectlExecPermission represents the kubectl exec ssh permission for policy (v2).

--- a/client/policy_test.go
+++ b/client/policy_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/borderzero/border0-go/client/mocks"
+	"github.com/borderzero/border0-go/lib/types/pointer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -56,8 +57,8 @@ var testPolicyDataV2 = PolicyDataV2{
 			TCPForwarding: &SSHTCPForwardingPermission{
 				AllowedConnections: &[]SSHTcpForwardingConnection{
 					{
-						DestinationAddress: "*",
-						DestinationPort:    "443",
+						DestinationAddress: pointer.To("*"),
+						DestinationPort:    pointer.To("443"),
 					},
 				},
 			},


### PR DESCRIPTION
## [[ME-3155](https://mysocket.atlassian.net/browse/ME-3155)] Match Policy Repo Model

These fields are pointer types in the policy repo. Im making them pointers here in order to just use the types here.

[ME-3155]: https://mysocket.atlassian.net/browse/ME-3155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of `DestinationAddress` and `DestinationPort` fields to prevent potential null value issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->