### PR TITLE
chore(ME-3491): add private network IP to socket config

### DIFF
--- a/types/service/configuration.go
+++ b/types/service/configuration.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"fmt"
+	"net/netip"
 
 	"github.com/borderzero/border0-go/lib/types/nilcheck"
 )
@@ -91,12 +92,50 @@ type ConnectorServiceConfiguration struct {
 	EndToEndEncryptionEnabled      bool          `json:"end_to_end_encryption_enabled"`
 	RecordingEnabled               bool          `json:"recording_enabled"`
 	Upstream                       Configuration `json:"upstream_configuration"`
+	PrivateNetworkIPv4             *string       `json:"private_network_ipv4"`
+	PrivateNetworkIPv6             *string       `json:"private_network_ipv6"`
 }
 
 // Validate validates the ConnectorServiceConfiguration.
 func (c *ConnectorServiceConfiguration) Validate() error {
 	if err := c.Upstream.Validate(); err != nil {
 		return fmt.Errorf("invalid upstream configuration: %w", err)
+	}
+
+	if c.PrivateNetworkIPv4 != nil {
+		if err := validateIP(c.PrivateNetworkIPv4, "ipv4"); err != nil {
+			return err
+		}
+	}
+
+	if c.PrivateNetworkIPv6 != nil {
+		if err := validateIP(c.PrivateNetworkIPv6, "ipv6"); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateIP(ipStr *string, version string) error {
+	if ipStr == nil {
+		return nil
+	}
+	addr, err := netip.ParseAddr(*ipStr)
+	if err != nil {
+		return fmt.Errorf("invalid IP address: %s", *ipStr)
+	}
+	switch version {
+	case "ipv4":
+		if !addr.Is4() {
+			return fmt.Errorf("expected an IPv4 address: %s", *ipStr)
+		}
+	case "ipv6":
+		if !addr.Is6() {
+			return fmt.Errorf("expected an IPv6 address: %s", *ipStr)
+		}
+	default:
+		return fmt.Errorf("unknown IP version: %s", version)
 	}
 	return nil
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced support for specifying and validating private network IPv4 and IPv6 addresses in the connector service configuration.
  
- **Bug Fixes**
	- Enhanced validation logic to ensure correct IP address formats for both IPv4 and IPv6 fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->