### PR TITLE
chore(ME-3528): add http access log recording type

### DIFF
--- a/types/recordings/recordings.go
+++ b/types/recordings/recordings.go
@@ -14,6 +14,9 @@ const (
 
 	// RecordingTypeBrowserSessionStream is the recording type for http DOM snapshot recordings e.g. rrweb.
 	RecordingTypeBrowserSessionStream = "browser_session_stream"
+
+	// RecordingTypeHTTPAccessLog is the recording type for http access logs in table format.
+	RecordingTypeHTTPAccessLog = "http_access_log"
 )
 
 // ValidRecordingTypes represents allowed values for recording types.
@@ -22,4 +25,5 @@ var ValidRecordingTypes = set.New(
 	RecordingTypeKubernetesAPIRequestLog,
 	RecordingTypeDatabaseQueryLog,
 	RecordingTypeBrowserSessionStream,
+	RecordingTypeHTTPAccessLog,
 )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced support for HTTP access logs as a valid recording type.
	- Expanded the set of allowed recording types to enhance functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->