### PR TITLE
feat(ME-3757): add network policies

### DIFF
--- a/client/policy.go
+++ b/client/policy.go
@@ -265,6 +265,7 @@ type PolicyPermissions struct {
 	RDP        *RDPPermissions        `json:"rdp,omitempty"`
 	VPN        *VPNPermissions        `json:"vpn,omitempty"`
 	Kubernetes *KubernetesPermissions `json:"kubernetes,omitempty"`
+	Network    *NetworkPermissions    `json:"network,omitempty"`
 }
 
 // DatabasePermissions represents database permissions for policy (v2).
@@ -358,3 +359,6 @@ type KubernetesRule struct {
 	ResourceNames []string `json:"resource_names,omitempty"`
 	// Note: support for selectors will come later...
 }
+
+// NetworkPermissions represents network service permissions for policy (v2).
+type NetworkPermissions struct{}

--- a/client/policy_test.go
+++ b/client/policy_test.go
@@ -78,11 +78,12 @@ var testPolicyDataV2 = PolicyDataV2{
 			MaxSessionDurationSeconds: &maxDuration,
 			AllowedUsernames:          &[]string{"root"},
 		},
-		HTTP: &HTTPPermissions{},
-		TLS:  &TLSPermissions{},
-		VNC:  &VNCPermissions{},
-		RDP:  &RDPPermissions{},
-		VPN:  &VPNPermissions{},
+		HTTP:    &HTTPPermissions{},
+		TLS:     &TLSPermissions{},
+		VNC:     &VNCPermissions{},
+		RDP:     &RDPPermissions{},
+		VPN:     &VPNPermissions{},
+		Network: &NetworkPermissions{},
 	},
 	Condition: PolicyConditionV2{
 		Who: PolicyWhoV2{


### PR DESCRIPTION
add network policy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `NetworkPermissions` type to enhance policy management capabilities.
	- Added a `Network` field to the `PolicyPermissions` structure for future network-related permissions.
  
- **Bug Fixes**
	- Updated test cases to account for the new `Network` permissions field in the `PolicyDataV2` structure, ensuring consistent API client behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->