### PR TITLE
[ME-3849] Exit Node Service Configurations

### DIFF
--- a/types/service/configuration.go
+++ b/types/service/configuration.go
@@ -34,6 +34,9 @@ const (
 
 	// ServiceTypeSubnetRoutes is the service type for subnet routes services (fka sockets).
 	ServiceTypeSubnetRoutes = "subnet_routes"
+
+	// ServiceTypeExitNode is the service type for exit node services (fka sockets).
+	ServiceTypeExitNode = "exit_node"
 )
 
 // Configuration represents upstream service configuration.
@@ -49,6 +52,7 @@ type Configuration struct {
 	RdpServiceConfiguration          *RdpServiceConfiguration          `json:"rdp_service_configuration,omitempty"`
 	KubernetesServiceConfiguration   *KubernetesServiceConfiguration   `json:"kubernetes_service_configuration,omitempty"`
 	SubnetRoutesServiceConfiguration *SubnetRoutesServiceConfiguration `json:"subnet_routes_service_configuration,omitempty"`
+	ExitNodeServiceConfiguration     *ExitNodeServiceConfiguration     `json:"exit_node_service_configuration,omitempty"`
 }
 
 type validatable interface {
@@ -67,6 +71,7 @@ func (c *Configuration) Validate() error {
 		ServiceTypeRdp:          c.RdpServiceConfiguration,
 		ServiceTypeKubernetes:   c.KubernetesServiceConfiguration,
 		ServiceTypeSubnetRoutes: c.SubnetRoutesServiceConfiguration,
+		ServiceTypeExitNode:     c.ExitNodeServiceConfiguration,
 	}
 
 	if currentConfig, ok := all[c.ServiceType]; ok {

--- a/types/service/exit_node_service_configuration.go
+++ b/types/service/exit_node_service_configuration.go
@@ -1,0 +1,14 @@
+package service
+
+// ExitNodeServiceConfiguration represents service
+// configuration for exit node services (fka sockets).
+type ExitNodeServiceConfiguration struct {
+	// NOTE(@adrianosela): uncomment if needed later along with
+	// the comments in exit_node_service_configuraiton_test.go
+	//
+	// DisableIPv4 bool `json:"disable_ipv4,omitempty"`
+	// DisableIPv6 bool `json:"disable_ipv6,omitempty"`
+}
+
+// Validate validates the ExitNodeServiceConfiguration.
+func (c *ExitNodeServiceConfiguration) Validate() error { return nil }

--- a/types/service/exit_node_service_configuration_test.go
+++ b/types/service/exit_node_service_configuration_test.go
@@ -1,0 +1,54 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ValidateExitNodeServiceConfiguration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		configuration *ExitNodeServiceConfiguration
+		expectError   bool
+	}{
+		{
+			name:          "Happy case for exit node with no network protocol disabled",
+			configuration: &ExitNodeServiceConfiguration{},
+			expectError:   false,
+		},
+
+		// NOTE(@adrianosela): uncomment if needed later
+		//
+		// {
+		// 	name:          "Happy case for exit node with ipv4 disabled",
+		// 	configuration: &ExitNodeServiceConfiguration{DisableIPv4: true},
+		// 	expectError:   false,
+		// },
+		// {
+		// 	name:          "Happy case for exit node with ipv6 disabled",
+		// 	configuration: &ExitNodeServiceConfiguration{DisableIPv6: true},
+		// 	expectError:   false,
+		// },
+		// {
+		// 	name:          "Happy case for exit node with ipv4 and ipv6 disabled",
+		// 	configuration: &ExitNodeServiceConfiguration{DisableIPv4: true, DisableIPv6: true},
+		// 	expectError:   false,
+		// },
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := test.configuration.Validate()
+			if test.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## [[ME-3849](https://mysocket.atlassian.net/browse/ME-3849)] Exit Node Service Config

[ME-3849]: https://mysocket.atlassian.net/browse/ME-3849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new service type for exit node services, enhancing configuration capabilities.
	- Added a new configuration structure specifically for exit node services.

- **Bug Fixes**
	- Updated validation logic to include the new exit node service configuration.

- **Tests**
	- Added tests for validating the exit node service configuration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->