### PR TITLE
Revert "[ME-4047] Add Exit Node Modes To Exit Node Service Config"

### DIFF
--- a/types/service/exit_node_service_configuration.go
+++ b/types/service/exit_node_service_configuration.go
@@ -1,56 +1,14 @@
 package service
 
-import (
-	"fmt"
-	"strings"
-
-	"github.com/borderzero/border0-go/lib/types/set"
-)
-
-const (
-	// ExitNodeModeIPv4Only is the exit node mode for
-	// routing only IPv4 traffic through the exit node.
-	ExitNodeModeIPv4Only = "IPV4_ONLY"
-
-	// ExitNodeModeIPv6Only is the exit node mode for
-	// routing only IPv6 traffic through the exit node.
-	ExitNodeModeIPv6Only = "IPV6_ONLY"
-
-	// ExitNodeModeDualStack is the exit node mode for
-	// routing all traffic (both IPv4 and IPv6) through
-	// the exit node
-	ExitNodeModeDualStack = "DUAL_STACK"
-)
-
-var (
-	// ExitNodeModes is a set containing valid values of
-	// exit node modes. Note that an empty value is also
-	// valid (defaulting to dual stack).
-	ExitNodeModes = set.New(
-		ExitNodeModeIPv4Only,
-		ExitNodeModeIPv6Only,
-		ExitNodeModeDualStack,
-	)
-
-	// exitNodeModeErrFmt is a format string used to return a validation error for an invalid exit node mode.
-	exitNodeModeErrFmt = fmt.Sprintf(
-		"exit node mode \"%%s\" is not valid, must be one of [ %s ]",
-		strings.Join(ExitNodeModes.Slice(), ", "),
-	)
-)
-
 // ExitNodeServiceConfiguration represents service
 // configuration for exit node services (fka sockets).
 type ExitNodeServiceConfiguration struct {
-	Mode string `json:"mode,omitempty"`
+	// NOTE(@adrianosela): uncomment if needed later along with
+	// the comments in exit_node_service_configuraiton_test.go
+	//
+	// DisableIPv4 bool `json:"disable_ipv4,omitempty"`
+	// DisableIPv6 bool `json:"disable_ipv6,omitempty"`
 }
 
 // Validate validates the ExitNodeServiceConfiguration.
-func (c *ExitNodeServiceConfiguration) Validate() error {
-	if c.Mode != "" {
-		if !ExitNodeModes.Has(c.Mode) {
-			return fmt.Errorf(exitNodeModeErrFmt, c.Mode)
-		}
-	}
-	return nil
-}
+func (c *ExitNodeServiceConfiguration) Validate() error { return nil }

--- a/types/service/exit_node_service_configuration_test.go
+++ b/types/service/exit_node_service_configuration_test.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,30 +13,30 @@ func Test_ValidateExitNodeServiceConfiguration(t *testing.T) {
 		name          string
 		configuration *ExitNodeServiceConfiguration
 		expectError   bool
-		expectedError error
 	}{
 		{
-			name:          "Happy case for exit node with empty configuration",
+			name:          "Happy case for exit node with no network protocol disabled",
 			configuration: &ExitNodeServiceConfiguration{},
 			expectError:   false,
 		},
-		{
-			name:          "Happy case for exit node with mode dual-stack",
-			configuration: &ExitNodeServiceConfiguration{Mode: ExitNodeModeDualStack},
-			expectError:   false,
-		},
 
-		{
-			name:          "Happy case for exit node with mode ipv4 only",
-			configuration: &ExitNodeServiceConfiguration{Mode: ExitNodeModeIPv4Only},
-			expectError:   false,
-		},
-		{
-			name:          "Fail validation when exit node mode is invalid",
-			configuration: &ExitNodeServiceConfiguration{Mode: "invalid"},
-			expectError:   true,
-			expectedError: fmt.Errorf(exitNodeModeErrFmt, "invalid"),
-		},
+		// NOTE(@adrianosela): uncomment if needed later
+		//
+		// {
+		// 	name:          "Happy case for exit node with ipv4 disabled",
+		// 	configuration: &ExitNodeServiceConfiguration{DisableIPv4: true},
+		// 	expectError:   false,
+		// },
+		// {
+		// 	name:          "Happy case for exit node with ipv6 disabled",
+		// 	configuration: &ExitNodeServiceConfiguration{DisableIPv6: true},
+		// 	expectError:   false,
+		// },
+		// {
+		// 	name:          "Happy case for exit node with ipv4 and ipv6 disabled",
+		// 	configuration: &ExitNodeServiceConfiguration{DisableIPv4: true, DisableIPv6: true},
+		// 	expectError:   false,
+		// },
 	}
 	for _, test := range tests {
 		test := test
@@ -46,7 +45,7 @@ func Test_ValidateExitNodeServiceConfiguration(t *testing.T) {
 
 			err := test.configuration.Validate()
 			if test.expectError {
-				assert.EqualError(t, err, test.expectedError.Error())
+				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
 			}


### PR DESCRIPTION
## Revert "[ME-4047] Add Exit Node Modes To Exit Node Service Config"

- https://mysocket.atlassian.net/browse/ME-4047

[ME-4047]: https://mysocket.atlassian.net/browse/ME-4047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified exit node service configuration validation
	- Removed exit node mode constants and validation checks
	- Updated test cases to reflect simplified validation process

- **Tests**
	- Modified test case to check for general error handling instead of specific error messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->