### PR TITLE
[ME-4181] Expose Percentile() in Ring Interface

### DIFF
--- a/lib/types/ring/ring.go
+++ b/lib/types/ring/ring.go
@@ -14,8 +14,9 @@ type Number interface {
 
 // Ring is an entity capable of keeping only the a number of most recent values.
 type Ring[N Number] interface {
-	Put(N)            // Put adds a sample to the Ring.
-	Average() float64 // Average computes the average value of all values in the Ring.
+	Put(N)                        // Put adds a sample to the Ring.
+	Average() float64             // Average computes the average value of all values in the Ring.
+	Percentile(p float32) float64 // Percentile computes a given percentile value of all values in the Ring.
 }
 
 // ring is the default implementation of the Ring interface.


### PR DESCRIPTION
## [[ME-4181](https://mysocket.atlassian.net/browse/ME-4183)] Expose Percentile() in Ring Interface

[ME-4181]: https://mysocket.atlassian.net/browse/ME-4181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a percentile calculation capability for numerical data collections, enabling users to compute specific statistical insights alongside existing average calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->