### PR TITLE
[ME-4276] Add Support for EC2 Instance Connect Endpoint ID

### DIFF
--- a/types/service/ssh_service_configuration.go
+++ b/types/service/ssh_service_configuration.go
@@ -87,6 +87,10 @@ const (
 	UsernameProviderUseConnectorUser = "use_connector_user"
 )
 
+const (
+	ec2InstanceConnectEndpointIdRegex = `^eice-[0-9a-f]{17}$`
+)
+
 // SshServiceConfiguration represents service
 // configuration for shell services (fka sockets).
 type SshServiceConfiguration struct {
@@ -146,11 +150,12 @@ type AwsSsmEcsTargetConfiguration struct {
 // for aws ec2 instance connect ssh services (fka sockets).
 type AwsEc2ICSshServiceConfiguration struct {
 	HostnameAndPort
-	UsernameProvider  string                 `json:"username_provider,omitempty"`
-	Username          string                 `json:"username,omitempty"`
-	Ec2InstanceId     string                 `json:"ec2_instance_id"`
-	Ec2InstanceRegion string                 `json:"ec2_instance_region"`
-	AwsCredentials    *common.AwsCredentials `json:"aws_credentials,omitempty"`
+	UsernameProvider             string                 `json:"username_provider,omitempty"`
+	Username                     string                 `json:"username,omitempty"`
+	Ec2InstanceId                string                 `json:"ec2_instance_id"`
+	Ec2InstanceRegion            string                 `json:"ec2_instance_region"`
+	Ec2InstanceConnectEndpointId string                 `json:"ec2_instance_connect_endpoint_id,omitempty"`
+	AwsCredentials               *common.AwsCredentials `json:"aws_credentials,omitempty"`
 }
 
 // DockerExecSshServiceConfiguration represents service
@@ -346,6 +351,15 @@ func (c *AwsEc2ICSshServiceConfiguration) Validate() error {
 		set.New(UsernameProviderPromptClient),
 	); err != nil {
 		return err
+	}
+	if c.Ec2InstanceConnectEndpointId != "" {
+		if !regexp.MustCompile(ec2InstanceConnectEndpointIdRegex).MatchString(c.Ec2InstanceConnectEndpointId) {
+			return fmt.Errorf(
+				"invalid ec2_instance_connect_endpoint_id: \"%s\" does not match regex \"%s\"",
+				c.Ec2InstanceConnectEndpointId,
+				ec2InstanceConnectEndpointIdRegex,
+			)
+		}
 	}
 	if c.Ec2InstanceId == "" {
 		return fmt.Errorf("ec2_instance_id is a required field")

--- a/types/service/ssh_service_configuration_test.go
+++ b/types/service/ssh_service_configuration_test.go
@@ -112,6 +112,23 @@ func Test_ValidateSshServiceConfiguration(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			name: "Happy case for ssh service type aws ec2 instance connect with endpoint",
+			configuration: &SshServiceConfiguration{
+				SshServiceType: SshServiceTypeAwsEc2InstanceConnect,
+				AwsEc2ICSshServiceConfiguration: &AwsEc2ICSshServiceConfiguration{
+					Ec2InstanceId:                mockEc2InstanceId,
+					Ec2InstanceRegion:            mockEc2InstanceRegion,
+					Ec2InstanceConnectEndpointId: "eice-01d8b08684ed01510",
+					HostnameAndPort: HostnameAndPort{
+						Hostname: "border0.com",
+						Port:     22,
+					},
+					UsernameProvider: UsernameProviderPromptClient,
+				},
+			},
+			expectedError: nil,
+		},
+		{
 			name: "Happy case for ssh service type built in ssh server",
 			configuration: &SshServiceConfiguration{
 				SshServiceType: SshServiceTypeConnectorBuiltIn,
@@ -659,6 +676,20 @@ func Test_AwsEc2ICSshServiceConfiguration(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			name: "Should succeed when all inputs are valid (incl. endpoint id)",
+			configuration: &AwsEc2ICSshServiceConfiguration{
+				HostnameAndPort: HostnameAndPort{
+					Hostname: "133.33.33.33",
+					Port:     22,
+				},
+				Ec2InstanceId:                mockInstanceId,
+				Ec2InstanceRegion:            mockInstanceRegion,
+				Ec2InstanceConnectEndpointId: "eice-01d8b08684ed01510",
+				UsernameProvider:             UsernameProviderPromptClient,
+			},
+			expectedError: nil,
+		},
+		{
 			name: "Should fail when hostname is missing",
 			configuration: &AwsEc2ICSshServiceConfiguration{
 				HostnameAndPort: HostnameAndPort{
@@ -718,6 +749,24 @@ func Test_AwsEc2ICSshServiceConfiguration(t *testing.T) {
 				UsernameProvider:  UsernameProviderPromptClient,
 			},
 			expectedError: fmt.Errorf("invalid ec2_instance_region: region \"%s\" is not a valid aws region", "bad region"),
+		},
+		{
+			name: "Should fail when ec2 instance connect endpoint id is invalid",
+			configuration: &AwsEc2ICSshServiceConfiguration{
+				Ec2InstanceId:                mockInstanceId,
+				Ec2InstanceRegion:            mockInstanceRegion,
+				Ec2InstanceConnectEndpointId: "notvalid",
+				HostnameAndPort: HostnameAndPort{
+					Hostname: "border0.com",
+					Port:     22,
+				},
+				UsernameProvider: UsernameProviderPromptClient,
+			},
+			expectedError: fmt.Errorf(
+				"invalid ec2_instance_connect_endpoint_id: \"%s\" does not match regex \"%s\"",
+				"notvalid",
+				ec2InstanceConnectEndpointIdRegex,
+			),
 		},
 		{
 			name: "Should fail when username provider is defined and username is missing",


### PR DESCRIPTION
## [[ME-4276](https://mysocket.atlassian.net/browse/ME-4276)] Add Support for EC2 Instance Connect Endpoint ID

[ME-4276]: https://mysocket.atlassian.net/browse/ME-4276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an optional configuration parameter for EC2 Instance Connect endpoints, ensuring that provided endpoint IDs adhere to a required format.
  
- **Tests**
  - Expanded test coverage to verify the new validation logic, confirming proper handling of both valid and invalid configuration inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->