### PR TITLE
[ME-4311] Move Snowflake Config to Top Level, Add Tests

### DIFF
--- a/types/service/configuration.go
+++ b/types/service/configuration.go
@@ -46,6 +46,9 @@ const (
 
 	// ServiceTypeElasticsearch is the service type for Elasticsearch services (fka sockets).
 	ServiceTypeElasticsearch = "elasticsearch"
+
+	// ServiceTypeSnowflake is the service type for Snowflake services (fka sockets).
+	ServiceTypeSnowflake = "snowflake"
 )
 
 // Configuration represents upstream service configuration.
@@ -63,6 +66,7 @@ type Configuration struct {
 	SubnetRouterServiceConfiguration  *SubnetRouterServiceConfiguration  `json:"subnet_router_service_configuration,omitempty"`
 	ExitNodeServiceConfiguration      *ExitNodeServiceConfiguration      `json:"exit_node_service_configuration,omitempty"`
 	ElasticsearchServiceConfiguration *ElasticsearchServiceConfiguration `json:"elasticsearch_service_configuration,omitempty"`
+	SnowflakeServiceConfiguration     *SnowflakeServiceConfiguration     `json:"snowflake_service_configuration,omitempty"`
 
 	// remove after february 2025
 	DEPRECATED_SubnetRoutesServiceConfiguration *SubnetRouterServiceConfiguration `json:"subnet_routes_service_configuration,omitempty"`
@@ -86,6 +90,7 @@ func (c *Configuration) Validate() error {
 		ServiceTypeSubnetRouter:  c.SubnetRouterServiceConfiguration,
 		ServiceTypeExitNode:      c.ExitNodeServiceConfiguration,
 		ServiceTypeElasticsearch: c.ElasticsearchServiceConfiguration,
+		ServiceTypeSnowflake:     c.SnowflakeServiceConfiguration,
 
 		// remove after february 2025
 		DEPRECATED_ServiceTypeSubnetRoutes: c.DEPRECATED_SubnetRoutesServiceConfiguration,

--- a/types/service/configuration_test.go
+++ b/types/service/configuration_test.go
@@ -66,6 +66,18 @@ func Test_Configuration_Validate(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			name: "Should succeed for valid snowflake socket",
+			configuration: &Configuration{
+				ServiceType: ServiceTypeSnowflake,
+				SnowflakeServiceConfiguration: &SnowflakeServiceConfiguration{
+					Account:  "account",
+					Username: "username",
+					Password: "password",
+				},
+			},
+			expectedError: nil,
+		},
+		{
 			name: "Should succeed for valid DEPRECATED subnet routes socket",
 			configuration: &Configuration{
 				ServiceType: DEPRECATED_ServiceTypeSubnetRoutes,

--- a/types/service/database_service_configuration.go
+++ b/types/service/database_service_configuration.go
@@ -15,7 +15,6 @@ const (
 	DatabaseServiceTypeAwsRds      = "aws_rds"      // AWS RDS database, supports IAM and password auth
 	DatabaseServiceTypeGcpCloudSql = "gcp_cloudsql" // Google Cloud SQL database, supports IAM, TLS and password auth
 	DatabaseServiceTypeAzureSql    = "azure_sql"    // Azure SQL database, supports SQL authentication, azure password auth
-	DatabaseServiceTypeSnowflake   = "snowflake"    // Snowflake databases
 )
 
 const (
@@ -151,7 +150,6 @@ type DatabaseServiceConfiguration struct {
 	AwsRds      *AwsRdsDatabaseServiceConfiguration      `json:"aws_rds_database_service_configuration,omitempty"`
 	GcpCloudSql *GcpCloudSqlDatabaseServiceConfiguration `json:"gcp_cloudsql_database_service_configuration,omitempty"`
 	AzureSql    *AzureSqlDatabaseServiceConfiguration    `json:"azure_sql_database_service_configuration,omitempty"`
-	Snowflake   *SnowflakeDatabaseServiceConfiguration   `json:"snowflake_database_service_configuration,omitempty"`
 }
 
 // Validate ensures that the `DatabaseServiceConfiguration` is valid.
@@ -161,7 +159,7 @@ func (config DatabaseServiceConfiguration) Validate() error {
 	}
 	switch config.DatabaseServiceType {
 	case DatabaseServiceTypeStandard:
-		if nilcheck.AnyNotNil(config.AwsRds, config.GcpCloudSql, config.AzureSql, config.Snowflake) {
+		if nilcheck.AnyNotNil(config.AwsRds, config.GcpCloudSql, config.AzureSql) {
 			return errors.New("database service type standard can only have standard configuration defined")
 		}
 		if config.Standard == nil {
@@ -169,7 +167,7 @@ func (config DatabaseServiceConfiguration) Validate() error {
 		}
 		return config.Standard.Validate()
 	case DatabaseServiceTypeAwsRds:
-		if nilcheck.AnyNotNil(config.Standard, config.GcpCloudSql, config.AzureSql, config.Snowflake) {
+		if nilcheck.AnyNotNil(config.Standard, config.GcpCloudSql, config.AzureSql) {
 			return errors.New("database service type aws_rds can only have aws rds configuration defined")
 		}
 		if config.AwsRds == nil {
@@ -177,7 +175,7 @@ func (config DatabaseServiceConfiguration) Validate() error {
 		}
 		return config.AwsRds.Validate()
 	case DatabaseServiceTypeGcpCloudSql:
-		if nilcheck.AnyNotNil(config.Standard, config.AwsRds, config.AzureSql, config.Snowflake) {
+		if nilcheck.AnyNotNil(config.Standard, config.AwsRds, config.AzureSql) {
 			return errors.New("database service type gcp_cloudsql can only have gcp cloudsql configuration defined")
 		}
 		if config.GcpCloudSql == nil {
@@ -185,21 +183,13 @@ func (config DatabaseServiceConfiguration) Validate() error {
 		}
 		return config.GcpCloudSql.Validate()
 	case DatabaseServiceTypeAzureSql:
-		if nilcheck.AnyNotNil(config.Standard, config.AwsRds, config.GcpCloudSql, config.Snowflake) {
+		if nilcheck.AnyNotNil(config.Standard, config.AwsRds, config.GcpCloudSql) {
 			return errors.New("database service type azure_sql can only have azure sql configuration defined")
 		}
 		if config.AzureSql == nil {
 			return errors.New("Azure SQL database service configuration is required")
 		}
 		return config.AzureSql.Validate()
-	case DatabaseServiceTypeSnowflake:
-		if nilcheck.AnyNotNil(config.Standard, config.AwsRds, config.GcpCloudSql, config.AzureSql) {
-			return errors.New("database service type snowflake can only have snowflake configuration defined")
-		}
-		if config.Snowflake == nil {
-			return errors.New("Snowflake database service configuration is required")
-		}
-		return config.Snowflake.Validate()
 	}
 	return fmt.Errorf("invalid database service type: %s", config.DatabaseServiceType)
 }
@@ -615,32 +605,6 @@ func (config AwsRdsIamAuthConfiguration) Validate() error {
 		if err := config.AwsCredentials.Validate(); err != nil {
 			return fmt.Errorf("invalid AWS credentials: %w", err)
 		}
-	}
-	return nil
-}
-
-// SnowflakeDatabaseServiceConfiguration represents service
-// configuration for snowflake database services (fka sockets).
-type SnowflakeDatabaseServiceConfiguration struct {
-	Account   string `json:"account"`
-	Username  string `json:"username"`
-	Password  string `json:"password"`
-	Database  string `json:"database"`
-	Schema    string `json:"schema"`
-	Warehouse string `json:"warehouse"`
-	Role      string `json:"role"`
-}
-
-// Validate ensures that the `SnowflakeDatabaseServiceConfiguration` has the required fields.
-func (config SnowflakeDatabaseServiceConfiguration) Validate() error {
-	if config.Account == "" {
-		return errors.New("account is required")
-	}
-	if config.Username == "" {
-		return errors.New("username is required")
-	}
-	if config.Password == "" {
-		return errors.New("password is required")
 	}
 	return nil
 }

--- a/types/service/database_service_configuration_test.go
+++ b/types/service/database_service_configuration_test.go
@@ -79,12 +79,6 @@ func Test_DatabaseServiceConfiguration_Validate(t *testing.T) {
 		},
 	}
 
-	testSnowflakeConfig := &SnowflakeDatabaseServiceConfiguration{
-		Account:  "account",
-		Username: "username",
-		Password: "password",
-	}
-
 	tests := []struct {
 		name  string
 		given DatabaseServiceConfiguration
@@ -176,23 +170,6 @@ func Test_DatabaseServiceConfiguration_Validate(t *testing.T) {
 			want: errors.New("Azure SQL database service configuration is required"),
 		},
 		{
-			name: "when snowflake type picked, other database service configs should be nil",
-			given: DatabaseServiceConfiguration{
-				DatabaseServiceType: DatabaseServiceTypeSnowflake,
-				Snowflake:           testSnowflakeConfig,
-				Standard:            testStandardConfig, // extra
-			},
-			want: errors.New("database service type snowflake can only have snowflake configuration defined"),
-		},
-		{
-			name: "snowflake type is picked, but snowflake config is missing",
-			given: DatabaseServiceConfiguration{
-				DatabaseServiceType: DatabaseServiceTypeSnowflake,
-				// snowflake config is missing
-			},
-			want: errors.New("Snowflake database service configuration is required"),
-		},
-		{
 			name: "happy path - standard config",
 			given: DatabaseServiceConfiguration{
 				DatabaseServiceType: DatabaseServiceTypeStandard,
@@ -221,14 +198,6 @@ func Test_DatabaseServiceConfiguration_Validate(t *testing.T) {
 			given: DatabaseServiceConfiguration{
 				DatabaseServiceType: DatabaseServiceTypeAzureSql,
 				AzureSql:            testAzureSqlConfig,
-			},
-			want: nil,
-		},
-		{
-			name: "happy path - snowflake config",
-			given: DatabaseServiceConfiguration{
-				DatabaseServiceType: DatabaseServiceTypeSnowflake,
-				Snowflake:           testSnowflakeConfig,
 			},
 			want: nil,
 		},

--- a/types/service/snowflake_service_configuration.go
+++ b/types/service/snowflake_service_configuration.go
@@ -1,0 +1,37 @@
+package service
+
+import (
+	"errors"
+)
+
+var (
+	errSnowflakeValidationNoAccount  = errors.New("account is required")
+	errSnowflakeValidationNoUsername = errors.New("username is required")
+	errSnowflakeValidationNoPassword = errors.New("password is required")
+)
+
+// SnowflakeServiceConfiguration represents service
+// configuration for snowflake services (fka sockets).
+type SnowflakeServiceConfiguration struct {
+	Account   string `json:"account"`
+	Username  string `json:"username"`
+	Password  string `json:"password"`
+	Database  string `json:"database"`
+	Schema    string `json:"schema"`
+	Warehouse string `json:"warehouse"`
+	Role      string `json:"role"`
+}
+
+// Validate ensures that the `SnowflakeServiceConfiguration` has the required fields.
+func (config SnowflakeServiceConfiguration) Validate() error {
+	if config.Account == "" {
+		return errSnowflakeValidationNoAccount
+	}
+	if config.Username == "" {
+		return errSnowflakeValidationNoUsername
+	}
+	if config.Password == "" {
+		return errSnowflakeValidationNoPassword
+	}
+	return nil
+}

--- a/types/service/snowflake_service_configuration_test.go
+++ b/types/service/snowflake_service_configuration_test.go
@@ -1,0 +1,61 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_SnowflakeServiceConfiguration_Validate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		given SnowflakeServiceConfiguration
+		want  error
+	}{
+		{
+			name: "fails when account is missing",
+			given: SnowflakeServiceConfiguration{
+				Username: "username",
+				Password: "password",
+			},
+			want: errSnowflakeValidationNoAccount,
+		},
+		{
+			name: "fails when username is missing",
+			given: SnowflakeServiceConfiguration{
+				Account:  "account",
+				Password: "password",
+			},
+			want: errSnowflakeValidationNoUsername,
+		},
+		{
+			name: "fails when password is missing",
+			given: SnowflakeServiceConfiguration{
+				Account:  "account",
+				Username: "username",
+			},
+			want: errSnowflakeValidationNoPassword,
+		},
+		{
+			name: "happy path",
+			given: SnowflakeServiceConfiguration{
+				Account:  "account",
+				Username: "username",
+				Password: "password",
+			},
+			want: nil,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := test.given.Validate()
+			assert.Equal(t, test.want, err)
+		})
+	}
+}


### PR DESCRIPTION
## [[ME-4311](https://mysocket.atlassian.net/browse/ME-4311)] Move Snowflake Config to Top Level,  Add Tests

[ME-4311]: https://mysocket.atlassian.net/browse/ME-4311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced support for configuring Snowflake services, allowing detailed setup with required credentials.
- **Refactor**
	- Removed legacy Snowflake configuration options from the database service setup to streamline overall service management.
- **Tests**
	- Expanded test coverage to validate the new Snowflake service configuration and eliminated outdated tests related to its previous database integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->