### PR TITLE
[ME-4311] Move Permission Snowflake Fields Out of Socket Config

### DIFF
--- a/types/service/snowflake_service_configuration.go
+++ b/types/service/snowflake_service_configuration.go
@@ -13,13 +13,9 @@ var (
 // SnowflakeServiceConfiguration represents service
 // configuration for snowflake services (fka sockets).
 type SnowflakeServiceConfiguration struct {
-	Account   string `json:"account"`
-	Username  string `json:"username"`
-	Password  string `json:"password"`
-	Database  string `json:"database"`
-	Schema    string `json:"schema"`
-	Warehouse string `json:"warehouse"`
-	Role      string `json:"role"`
+	Account  string `json:"account"`
+	Username string `json:"username"`
+	Password string `json:"password"`
 }
 
 // Validate ensures that the `SnowflakeServiceConfiguration` has the required fields.


### PR DESCRIPTION
## [[ME-4311](https://mysocket.atlassian.net/browse/ME-4311)] Move Permission Snowflake Fields Out of Socket Config

These fields will go in the "Snowflake" policy as lists e.g. "databases", "schemas", "warehouses", and "roles".

[ME-4311]: https://mysocket.atlassian.net/browse/ME-4311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the Snowflake integration configuration by reducing the number of setup parameters to only the essential connection details. Users relying on previous extended settings may need to adjust their configuration accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->