### PR TITLE
[ME-4360] Bump golang-jwt to v5.2.2

### DIFF
--- a/client/api_client.go
+++ b/client/api_client.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 // APIClient is the client for the Border0 API.

--- a/client/api_client_test.go
+++ b/client/api_client_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/borderzero/border0-go/client/mocks"
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/client/authentication.go
+++ b/client/authentication.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/borderzero/border0-go/client/auth"
 	"github.com/cenkalti/backoff"
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/skratchdot/open-golang/open"
 	"golang.org/x/term"
 )

--- a/client/mocks/client_http_requester.go
+++ b/client/mocks/client_http_requester.go
@@ -21,7 +21,7 @@ func (_m *ClientHTTPRequester) EXPECT() *ClientHTTPRequester_Expecter {
 	return &ClientHTTPRequester_Expecter{mock: &_m.Mock}
 }
 
-// Close provides a mock function with given fields:
+// Close provides a mock function with no fields
 func (_m *ClientHTTPRequester) Close() {
 	_m.Called()
 }
@@ -49,7 +49,7 @@ func (_c *ClientHTTPRequester_Close_Call) Return() *ClientHTTPRequester_Close_Ca
 }
 
 func (_c *ClientHTTPRequester_Close_Call) RunAndReturn(run func()) *ClientHTTPRequester_Close_Call {
-	_c.Call.Return(run)
+	_c.Run(run)
 	return _c
 }
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.6
 require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cenkalti/backoff/v4 v4.3.0
-	github.com/golang-jwt/jwt v3.2.2+incompatible
+	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/crypto v0.36.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK3
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
-github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
+github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 h1:JIAuq3EEf9cgbU6AtGPK4CTG3Zf6CKMNqf0MHTggAUA=

--- a/listen/mocks/api_client_requester.go
+++ b/listen/mocks/api_client_requester.go
@@ -8,7 +8,7 @@ import (
 
 	context "context"
 
-	jwt "github.com/golang-jwt/jwt"
+	jwt "github.com/golang-jwt/jwt/v5"
 
 	mock "github.com/stretchr/testify/mock"
 )
@@ -2043,7 +2043,7 @@ func (_c *APIClientRequester_Sockets_Call) RunAndReturn(run func(context.Context
 	return _c
 }
 
-// TokenClaims provides a mock function with given fields:
+// TokenClaims provides a mock function with no fields
 func (_m *APIClientRequester) TokenClaims() (jwt.MapClaims, error) {
 	ret := _m.Called()
 


### PR DESCRIPTION
## [[ME-4360](https://mysocket.atlassian.net/browse/ME-4360)] Bump golang-jwt to v5.2.2

[ME-4360]: https://mysocket.atlassian.net/browse/ME-4360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Upgraded the authentication library to the latest version for enhanced security and compatibility.
  - Updated dependency references across the codebase to maintain consistent performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->