### PR TITLE
ME-4889: add activeOnly url param to socket endpoint

### DIFF
--- a/client/socket.go
+++ b/client/socket.go
@@ -25,7 +25,7 @@ type SocketService interface {
 // a Border0 organization.
 func (api *APIClient) Socket(ctx context.Context, idOrName string) (out *Socket, err error) {
 	out = new(Socket)
-	_, err = api.request(ctx, http.MethodGet, fmt.Sprintf("/socket/%s", idOrName), nil, out)
+	_, err = api.request(ctx, http.MethodGet, fmt.Sprintf("/socket/%s?activeOnly=true", idOrName), nil, out)
 	if err != nil {
 		if NotFound(err) {
 			return nil, fmt.Errorf("socket [%s] not found: %w", idOrName, err)

--- a/client/socket_test.go
+++ b/client/socket_test.go
@@ -33,7 +33,7 @@ func Test_APIClient_Socket(t *testing.T) {
 			name: "failed to get socket",
 			mockRequester: func(ctx context.Context, requester *mocks.ClientHTTPRequester) {
 				requester.EXPECT().
-					Request(ctx, http.MethodGet, defaultBaseURL+"/socket/test-name", nil, new(Socket)).
+					Request(ctx, http.MethodGet, defaultBaseURL+"/socket/test-name?activeOnly=true", nil, new(Socket)).
 					Return(http.StatusBadRequest, errors.New("failed to get socket"))
 			},
 			givenIDOrName: "test-name",
@@ -44,7 +44,7 @@ func Test_APIClient_Socket(t *testing.T) {
 			name: "404 not found error returned, let's make sure we wrap the error with more info",
 			mockRequester: func(ctx context.Context, requester *mocks.ClientHTTPRequester) {
 				requester.EXPECT().
-					Request(ctx, http.MethodGet, defaultBaseURL+"/socket/test-name", nil, new(Socket)).
+					Request(ctx, http.MethodGet, defaultBaseURL+"/socket/test-name?activeOnly=true", nil, new(Socket)).
 					Return(http.StatusNotFound, Error{Code: http.StatusNotFound, Message: "socket not found"})
 			},
 			givenIDOrName: "test-name",
@@ -56,7 +56,7 @@ func Test_APIClient_Socket(t *testing.T) {
 				// have to use On() instead of EXPECT() because we need to set the output
 				// and the Run() function would raise nil pointer panic if we use it with
 				// EXPECT()
-				requester.On("Request", ctx, http.MethodGet, defaultBaseURL+"/socket/test-name", nil, new(Socket)).
+				requester.On("Request", ctx, http.MethodGet, defaultBaseURL+"/socket/test-name?activeOnly=true", nil, new(Socket)).
 					Return(http.StatusOK, nil).
 					Run(func(args mock.Arguments) {
 						output := args.Get(4).(*Socket)

--- a/lib/types/jsoneq/jsoneq.go
+++ b/lib/types/jsoneq/jsoneq.go
@@ -1,0 +1,122 @@
+package jsoneq
+
+import (
+	"bytes"
+	"encoding/json"
+	"sort"
+)
+
+// options is an internal options object used
+// for selective pruning of zeroed JSON fields.
+type options struct {
+	pruneEmptyObjects bool
+	pruneEmptySlices  bool
+	pruneEmptyStrings bool
+}
+
+// Option represents an option for testing JSON object equality.
+type Option func(*options)
+
+func PruneEmptyObjects() Option { return func(o *options) { o.pruneEmptyObjects = true } }
+func PruneEmptySlices() Option  { return func(o *options) { o.pruneEmptySlices = true } }
+func PruneEmptyStrings() Option { return func(o *options) { o.pruneEmptyStrings = true } }
+
+// AreEqual compares two JSON strings for semantic equality, ignoring array ordering.
+func AreEqual(a, b string, opts ...Option) bool {
+	var ai, bi any
+	if err := json.Unmarshal([]byte(a), &ai); err != nil {
+		return false
+	}
+	if err := json.Unmarshal([]byte(b), &bi); err != nil {
+		return false
+	}
+	Prune(ai, opts...)
+	Prune(bi, opts...)
+	Canonicalize(ai)
+	Canonicalize(bi)
+	ab, err := json.Marshal(ai)
+	if err != nil {
+		return false
+	}
+	bb, err := json.Marshal(bi)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(ab, bb)
+}
+
+// Prune recursively removes default JSON values given some options.
+func Prune(v any, opts ...Option) {
+	o := &options{}
+	for _, opt := range opts {
+		opt(o)
+	}
+	dropEmptyValues(v, o)
+}
+
+func dropEmptyValues(v any, opts *options) {
+	switch x := v.(type) {
+	case []any:
+		for _, e := range x {
+			dropEmptyValues(e, opts)
+		}
+	case map[string]any:
+		for k, e := range x {
+			switch val := e.(type) {
+			case string:
+				if !opts.pruneEmptyStrings {
+					continue
+				}
+
+				if val == "" {
+					delete(x, k)
+					continue
+				}
+			case nil:
+				if !opts.pruneEmptyObjects {
+					continue
+				}
+				delete(x, k)
+				continue
+			case []any:
+				if !opts.pruneEmptySlices {
+					continue
+				}
+				if len(val) == 0 {
+					delete(x, k)
+					continue
+				}
+				dropEmptyValues(val, opts)
+			case map[string]any:
+				if !opts.pruneEmptyObjects {
+					continue
+				}
+				dropEmptyValues(val, opts)
+				if len(val) == 0 {
+					delete(x, k)
+				}
+			default:
+				dropEmptyValues(e, opts)
+			}
+		}
+	}
+}
+
+// Canonicalize recursively sorts arrays within a JSON-like structure.
+func Canonicalize(v any) {
+	switch x := v.(type) {
+	case []any:
+		for i := range x {
+			Canonicalize(x[i])
+		}
+		sort.Slice(x, func(i, j int) bool {
+			bi, _ := json.Marshal(x[i])
+			bj, _ := json.Marshal(x[j])
+			return string(bi) < string(bj)
+		})
+	case map[string]any:
+		for _, v := range x {
+			Canonicalize(v)
+		}
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved socket fetching to only return active sockets when searching by ID or name.

* **New Features**
  * Introduced a JSON comparison utility that checks semantic equality while ignoring array order and optionally pruning empty values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->