### PR TITLE
chore(ME-4832): remove old policy socket tags

### DIFF
--- a/client/policy.go
+++ b/client/policy.go
@@ -175,7 +175,6 @@ type Policy struct {
 	CreatedAt   time.Time           `json:"created_at"`
 	SocketIDs   []string            `json:"socket_ids"`
 	Deleted     bool                `json:"deleted"`
-	SocketTags  map[string]string   `json:"socket_tags"`
 	TagRules    []map[string]string `json:"tag_rules"`
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the "SocketTags" field from policy settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->