### PR TITLE
ME-4899: use server Retry-After value on 429 responses

### DIFF
--- a/client/server_info.go
+++ b/client/server_info.go
@@ -1,0 +1,23 @@
+package client
+
+import (
+	"context"
+	"net/http"
+)
+
+type ServerInfoService interface {
+	ServerInfo(context.Context) (*ServerInfo, error)
+}
+
+func (api *APIClient) ServerInfo(ctx context.Context) (*ServerInfo, error) {
+	info := new(ServerInfo)
+	_, err := api.request(ctx, http.MethodGet, "/serverinfo", nil, info)
+	if err != nil {
+		return nil, err
+	}
+	return info, nil
+}
+
+type ServerInfo struct {
+	Primary *bool `json:"primary,omitempty"`
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling of rate limiting: The client now respects the server's `Retry-After` header when retrying requests after receiving a 429 (Too Many Requests) response.
  * If a `Retry-After` value is provided by the server, the client will wait for the specified duration before retrying, ensuring better compliance with server rate limits.
  * Added server information retrieval capability, allowing clients to query server status details. 

* **Bug Fixes**
  * More accurate retry timing for rate-limited requests, reducing unnecessary or premature retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->