### PR TITLE
[ME-4951] Add database name override to config

### DIFF
--- a/types/service/database_service_configuration.go
+++ b/types/service/database_service_configuration.go
@@ -45,6 +45,7 @@ const (
 // - standard (when database service type is standard)
 //     - hostname and port
 //     - database protocol: mysql, postgres
+//     - database_name_override (optional)
 //     - authentication type: username_and_password, tls
 //     - username and password auth (when authentication type is username_and_password)
 //         - username
@@ -58,6 +59,7 @@ const (
 // - aws rds (when database service type is aws_rds)
 //     - hostname and port
 //     - database protocol: mysql, postgres
+//     - database_name_override (optional)
 //     - authentication type: username_and_password, tls
 //     - username and password auth (when authentication type is username_and_password)
 //         - username
@@ -73,6 +75,7 @@ const (
 //     - standard (when cloudsql_connector_enabled is false)
 //         - hostname and port
 //         - database protocol: mysql
+//         - database_name_override (optional)
 //         - authentication type: username_and_password, tls
 //         - username and password auth (when authentication type is username_and_password)
 //             - username
@@ -85,6 +88,7 @@ const (
 //             - key
 //     - connector (when cloudsql_connector_enabled is true)
 //         - database protocol: mysql, postgres
+//         - database_name_override (optional)
 //         - authentication type: username_password, iam
 //	   - username and password auth (when authentication type is username_and_password)
 //             - username

--- a/types/service/database_service_configuration.go
+++ b/types/service/database_service_configuration.go
@@ -160,6 +160,8 @@ type StandardDatabaseServiceConfiguration struct {
 	DatabaseProtocol   string `json:"protocol"`
 	AuthenticationType string `json:"authentication_type"`
 
+	DatabaseNameOverride string `json:"database_name_override,omitempty"`
+
 	UsernameAndPasswordAuth *DatabaseUsernameAndPasswordAuthConfiguration `json:"username_and_password_auth_configuration,omitempty"`
 	TlsAuth                 *DatabaseTlsAuthConfiguration                 `json:"tls_auth_configuration,omitempty"`
 }
@@ -207,6 +209,8 @@ type AwsRdsDatabaseServiceConfiguration struct {
 
 	DatabaseProtocol   string `json:"protocol"`
 	AuthenticationType string `json:"authentication_type"`
+
+	DatabaseNameOverride string `json:"database_name_override,omitempty"`
 
 	UsernameAndPasswordAuth *AwsRdsUsernameAndPasswordAuthConfiguration `json:"username_and_password_auth_configuration,omitempty"`
 	IamAuth                 *AwsRdsIamAuthConfiguration                 `json:"iam_auth_configuration,omitempty"`
@@ -293,8 +297,9 @@ func (config GcpCloudSqlDatabaseServiceConfiguration) Validate() error {
 type GcpCloudSqlStandardConfiguration struct {
 	HostnameAndPort
 
-	DatabaseProtocol   string `json:"protocol"`
-	AuthenticationType string `json:"authentication_type"`
+	DatabaseProtocol     string `json:"protocol"`
+	AuthenticationType   string `json:"authentication_type"`
+	DatabaseNameOverride string `json:"database_name_override,omitempty"`
 
 	UsernameAndPasswordAuth *DatabaseUsernameAndPasswordAuthConfiguration `json:"username_and_password_auth_configuration,omitempty"`
 	TlsAuth                 *DatabaseTlsAuthConfiguration                 `json:"tls_auth_configuration,omitempty"`


### PR DESCRIPTION
# description
- add the database override configuration for force the database name independent of what the customer select

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying an optional database name override in database service configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->