### PR TITLE
[ME-4845] Improve Debouncer Lib, fix send on close chan

### DIFF
--- a/lib/debouncer/config.go
+++ b/lib/debouncer/config.go
@@ -1,0 +1,27 @@
+package debouncer
+
+import "time"
+
+const (
+	defaultDebounceTime = time.Second
+	defaultMaxWaitTime  = time.Duration(-1)
+)
+
+type config struct {
+	debounceTime time.Duration
+	maxWaitTime  time.Duration
+}
+
+func newDefaultConfig() *config {
+	return &config{
+		debounceTime: defaultDebounceTime,
+		maxWaitTime:  defaultMaxWaitTime,
+	}
+}
+
+func (c *config) Apply(opts ...Option) *config {
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}

--- a/lib/debouncer/debouncer_test.go
+++ b/lib/debouncer/debouncer_test.go
@@ -1,0 +1,25 @@
+package debouncer
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestDebouncerCloseRace(t *testing.T) {
+
+	d := New(func(int) {}, WithDebounceTime(1*time.Millisecond))
+	var wg sync.WaitGroup
+
+	for i := range 1000 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			d.Do(i)
+		}(i)
+	}
+
+	time.Sleep(2 * time.Millisecond)
+	d.Close()
+	wg.Wait()
+}

--- a/lib/debouncer/options.go
+++ b/lib/debouncer/options.go
@@ -1,0 +1,14 @@
+package debouncer
+
+import "time"
+
+type Option func(*config)
+
+// WithDebounceTime sets the debounce time i.e. how long to wait
+// without further invocations before firing. Defaults to 1 second.
+func WithDebounceTime(d time.Duration) Option { return func(c *config) { c.debounceTime = d } }
+
+// WithMaxWaitTime sets the max wait time i.e. maximum time spent deferring invocations
+// due to new invocations. Defaults to no maximum i.e. never fire for infinite successive
+// invocations within the debounce time.
+func WithMaxWaitTime(d time.Duration) Option { return func(c *config) { c.maxWaitTime = d } }


### PR DESCRIPTION
## [ME-4845] Improve Debouncer Lib, fix send on close chan

[ME-4845]: https://mysocket.atlassian.net/browse/ME-4845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added functional options to configure debounce timing and an optional max-wait.
  * Introduced an option-based constructor for flexible setup.
* **Refactor**
  * Reworked internal debouncer to a channel-driven processor with explicit lifecycle and safer shutdown.
  * Improved concurrency safety, drain behavior, and flush/close semantics under heavy load.
* **Tests**
  * Added a high-concurrency stress test validating safe operation during concurrent invocations and shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->