### PR TITLE
[ME-4981] Remove Unused Error

### DIFF
--- a/lib/uuip/uuip.go
+++ b/lib/uuip/uuip.go
@@ -8,8 +8,8 @@ import (
 )
 
 // UUIDToIPv6 converts a UUID to a netip.Addr (IPv6).
-func UUIDToIPv6(u uuid.UUID) (netip.Addr, error) {
-	return netip.AddrFrom16(u), nil
+func UUIDToIPv6(u uuid.UUID) netip.Addr {
+	return netip.AddrFrom16(u)
 }
 
 // IPv6ToUUID converts a netip.Addr (IPv6) to a UUID.

--- a/lib/uuip/uuip_test.go
+++ b/lib/uuip/uuip_test.go
@@ -11,10 +11,7 @@ func TestUUIDToIPv6AndBack(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		originalUUID := uuid.New()
 
-		ipv6, err := UUIDToIPv6(originalUUID)
-		if err != nil {
-			t.Fatalf("UUIDToIPv6 failed: %v", err)
-		}
+		ipv6 := UUIDToIPv6(originalUUID)
 
 		decodedUUID, err := IPv6ToUUID(ipv6)
 		if err != nil {
@@ -42,10 +39,7 @@ func TestUUIDToIPv6_InvalidLength(t *testing.T) {
 	copy(shortUUID[:], []byte("short"))
 
 	// Should still pass because uuid.UUID is always 16 bytes (even if garbage)
-	ipv6, err := UUIDToIPv6(shortUUID)
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	ipv6 := UUIDToIPv6(shortUUID)
 
 	// Check it's a valid IPv6 address
 	if !ipv6.Is6() {


### PR DESCRIPTION
## [[ME-4981](https://mysocket.atlassian.net/browse/ME-4981) Remove Unused Error

[ME-4981]: https://mysocket.atlassian.net/browse/ME-4981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal UUID-to-IPv6 conversion to return a direct address value, removing redundant error handling and reducing overhead. Reverse conversion remains unchanged.
* **Chores**
  * Updated internal references to align with the streamlined API.
* **Impact**
  * No user-facing changes. Developers consuming internal APIs may need to update call sites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->