### PR TITLE
[ME-5001] Add Semaphore Implementation

### DIFF
--- a/lib/sem/iface.go
+++ b/lib/sem/iface.go
@@ -1,0 +1,13 @@
+package sem
+
+import "context"
+
+// Semaphore is the interface that wraps basic Acquire and Release
+// methods to control access to a limited resource pool.
+type Semaphore interface {
+	// Acquire blocks until a slot is available in the semaphore.
+	Acquire(context.Context) error
+
+	// Release frees a slot in the semaphore.
+	Release()
+}

--- a/lib/sem/simple.go
+++ b/lib/sem/simple.go
@@ -1,0 +1,32 @@
+package sem
+
+import "context"
+
+// semaphore is a concrete implementation of
+// the Semaphore interface using a buffered channel.
+type semaphore struct {
+	ch chan struct{}
+}
+
+// New returns a Semaphore that allows up to n concurrent holders.
+func New(n uint) Semaphore {
+	return &semaphore{
+		// NOTE: This channel is intentionally never closed.
+		// It will be garbage collected when there are no goroutines
+		// blocked on it and no references to the semaphore object.
+		ch: make(chan struct{}, n),
+	}
+}
+
+// Acquire takes a slot in the semaphore, blocking if none are available.
+func (s *semaphore) Acquire(ctx context.Context) error {
+	select {
+	case s.ch <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// Release frees a previously acquired slot in the semaphore.
+func (s *semaphore) Release() { <-s.ch }


### PR DESCRIPTION
## [[ME-5001](https://mysocket.atlassian.net/browse/ME-5001)] Add Semaphore Implementation

[ME-5001]: https://mysocket.atlassian.net/browse/ME-5001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced an internal concurrency-limiting component with context-aware acquisition, release, and close operations.
  * Enables controlled parallel operations and responsive cancellation in long-running tasks.
  * Enhances robustness and predictability under load; no action required from end-users.
  * No UI or publicly documented API changes included in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->