### PR TITLE
Add Tailscale auth token to connector

### DIFF
--- a/client/connector.go
+++ b/client/connector.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 )
 
 // ConnectorService is an interface for API client methods that interact with Border0 API to manage connectors and connector tokens.
@@ -118,6 +119,14 @@ func (api *APIClient) DeleteConnectorToken(ctx context.Context, connectorID, tok
 	return nil
 }
 
+// TailscaleAuthKey is the Tailscale auth key issued by the Border0 API on behalf of the
+// organization's Tailscale integration.
+type TailscaleAuthKey struct {
+	ID      string     `json:"id"`
+	Key     string     `json:"key"`
+	Expires *time.Time `json:"expires,omitempty"`
+}
+
 // Connector represents a connector in your Border0 organization.
 type Connector struct {
 	// input and output fields
@@ -130,6 +139,9 @@ type Connector struct {
 	// built-in SSH service
 	BuiltInSshServiceEnabled bool    `json:"built_in_ssh_service_enabled,omitempty"`
 	BuiltInSshService        *Socket `json:"built_in_ssh_service,omitempty"` // optional, nil if built-in SSH service is disabled
+
+	// TailscaleAuthKey is only present for tailscale managed connectors
+	TailscaleAuthKey *TailscaleAuthKey `json:"tailscale_auth_key,omitempty"`
 }
 
 // ConnectorToken represents a token for a connector.


### PR DESCRIPTION
# Description

Add tailscale auth key in the connector model, this only be used for tailscale managed organizations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Connectors now support carrying Tailscale authentication key information, including key ID, value, and optional expiration timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->